### PR TITLE
Remove "sync file events" option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,11 +95,6 @@
                     },
                     "description": "Arguments for clangd server"
                 },
-                "clangd.syncFileEvents": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether or not to send file events to clangd (File created, changed or deleted). This can be disabled for performance consideration."
-                },
                 "clangd.trace": {
                     "type": "string",
                     "description": "Names a file that clangd should log a performance trace to, in chrome trace-viewer JSON format."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,8 +45,6 @@ class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
  *  activated the very first time a command is executed.
  */
 export function activate(context: vscode.ExtensionContext) {
-  const syncFileEvents = getConfig<boolean>('syncFileEvents', true);
-
   const clangd: vscodelc.Executable = {
     command : getConfig<string>('path'),
     args : getConfig<string[]>('arguments')
@@ -68,9 +66,6 @@ export function activate(context: vscode.ExtensionContext) {
       { scheme: 'file', language: 'objective-c' },
       { scheme: 'file', language: 'objective-cpp' }
     ],
-    synchronize: !syncFileEvents ? undefined : {
-      // FIXME: send sync file events when clangd provides implementations.
-    },
     initializationOptions: { clangdFileStatus: true },
     // Do not switch to output window when clangd returns output.
     revealOutputChannelOn: vscodelc.RevealOutputChannelOn.Never,


### PR DESCRIPTION
Clangd still doesn't listen to these events, and these days it can
dynamically register file watchers if it wants to start.