### PR TITLE
Fix clang-format style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,3 @@
 BasedOnStyle: LLVM
+# Objects like {a: 0}, not { a : 0 }.
+SpacesInContainerLiterals: false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,31 +46,31 @@ class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
  */
 export function activate(context: vscode.ExtensionContext) {
   const clangd: vscodelc.Executable = {
-    command : getConfig<string>('path'),
-    args : getConfig<string[]>('arguments')
+    command: getConfig<string>('path'),
+    args: getConfig<string[]>('arguments')
   };
   const traceFile = getConfig<string>('trace');
   if (!!traceFile) {
-    const trace = {CLANGD_TRACE : traceFile};
-    clangd.options = {env : {...process.env, ...trace}};
+    const trace = {CLANGD_TRACE: traceFile};
+    clangd.options = {env: {...process.env, ...trace}};
   }
   const serverOptions: vscodelc.ServerOptions = clangd;
 
   const clientOptions: vscodelc.LanguageClientOptions = {
     // Register the server for c-family and cuda files.
     documentSelector: [
-      { scheme: 'file', language: 'c' },
-      { scheme: 'file', language: 'cpp' },
+      {scheme: 'file', language: 'c'},
+      {scheme: 'file', language: 'cpp'},
       // CUDA is not supported by vscode, but our extension does supports it.
-      { scheme: 'file', language: 'cuda' },
-      { scheme: 'file', language: 'objective-c' },
-      { scheme: 'file', language: 'objective-cpp' }
+      {scheme: 'file', language: 'cuda'},
+      {scheme: 'file', language: 'objective-c'},
+      {scheme: 'file', language: 'objective-cpp'},
     ],
-    initializationOptions: { clangdFileStatus: true },
+    initializationOptions: {clangdFileStatus: true},
     // Do not switch to output window when clangd returns output.
     revealOutputChannelOn: vscodelc.RevealOutputChannelOn.Never,
 
-    // We hack up the completion items a bit to prevent VSCode from re-ranking them
+    // We hack up the completion items a bit to prevent VSCode from re-ranking
     // and throwing away all our delicious signals like type information.
     //
     // VSCode sorts by (fuzzymatch(prefix, item.filterText), item.sortText)
@@ -81,20 +81,22 @@ export function activate(context: vscode.ExtensionContext) {
     // differences in how fuzzy filtering is applies, e.g. enable dot-to-arrow
     // fixes in completion.
     //
-    // We also have to mark the list as incomplete to force retrieving new rankings.
+    // We also mark the list as incomplete to force retrieving new rankings.
     // See https://github.com/microsoft/language-server-protocol/issues/898
     middleware: {
-      provideCompletionItem: async (document, position, context, token, next) => {
-        let list = await next(document, position, context, token);
-        let items = (Array.isArray(list) ? list : list.items).map(item => {
-          // Gets the prefix used by VSCode when doing fuzzymatch.
-          let prefix = document.getText(new vscode.Range(item.range.start, position))
-          if (prefix)
-            item.filterText = prefix + "_" + item.filterText;
-          return item;
-        })
-        return new vscode.CompletionList(items, /*isIncomplete=*/true);
-      }
+      provideCompletionItem:
+          async (document, position, context, token, next) => {
+            let list = await next(document, position, context, token);
+            let items = (Array.isArray(list) ? list : list.items).map(item => {
+              // Gets the prefix used by VSCode when doing fuzzymatch.
+              let prefix =
+                  document.getText(new vscode.Range(item.range.start, position))
+              if (prefix)
+              item.filterText = prefix + "_" + item.filterText;
+              return item;
+            })
+            return new vscode.CompletionList(items, /*isIncomplete=*/ true);
+          }
     },
   };
 

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -82,10 +82,10 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
     // Extend the ClientCapabilities type and add semantic highlighting
     // capability to the object.
     const textDocumentCapabilities: vscodelc.TextDocumentClientCapabilities&
-        {semanticHighlightingCapabilities?: {semanticHighlighting : boolean}} =
+        {semanticHighlightingCapabilities?: {semanticHighlighting: boolean}} =
         capabilities.textDocument;
     textDocumentCapabilities.semanticHighlightingCapabilities = {
-      semanticHighlighting : true,
+      semanticHighlighting: true,
     };
   }
 
@@ -102,7 +102,7 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
     // object but to access the data we must first extend the ServerCapabilities
     // type.
     const serverCapabilities: vscodelc.ServerCapabilities&
-        {semanticHighlighting?: {scopes : string[][]}} = capabilities;
+        {semanticHighlighting?: {scopes: string[][]}} = capabilities;
     if (!serverCapabilities.semanticHighlighting)
       return;
     this.scopeLookupTable = serverCapabilities.semanticHighlighting.scopes;
@@ -129,7 +129,7 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
 
   handleNotification(params: SemanticHighlightingParams) {
     const lines: SemanticHighlightingLine[] = params.lines.map(
-        (line) => ({line : line.line, tokens : decodeTokens(line.tokens)}));
+        (line) => ({line: line.line, tokens: decodeTokens(line.tokens)}));
     this.highlighter.highlight(vscode.Uri.parse(params.textDocument.uri),
                                lines);
   }
@@ -153,7 +153,7 @@ export function decodeTokens(tokens: string): SemanticHighlightingToken[] {
     const lenKind = buf.readUInt32BE((i + 1) * uint32Size);
     const scopeIndex = lenKind & scopeMask;
     const len = lenKind >>> lenShift;
-    retTokens.push({character : start, scopeIndex : scopeIndex, length : len});
+    retTokens.push({character: start, scopeIndex: scopeIndex, length: len});
   }
 
   return retTokens;
@@ -192,10 +192,10 @@ export class Highlighter {
         // If there exists no rule for this scope the matcher returns an empty
         // color. That's ok because vscode does not do anything when applying
         // empty decorations.
-        color : themeRuleMatcher.getBestThemeRule(scopes[0]).foreground,
+        color: themeRuleMatcher.getBestThemeRule(scopes[0]).foreground,
         // If the rangeBehavior is set to Open in any direction the
         // highlighting becomes weird in certain cases.
-        rangeBehavior : vscode.DecorationRangeBehavior.ClosedClosed,
+        rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
       };
       return vscode.window.createTextEditorDecorationType(options);
     });
@@ -293,7 +293,7 @@ export class ThemeRuleMatcher {
   getBestThemeRule(scope: string): TokenColorRule {
     if (this.bestRuleCache.has(scope))
       return this.bestRuleCache.get(scope);
-    let bestRule: TokenColorRule = {scope : '', foreground : ''};
+    let bestRule: TokenColorRule = {scope: '', foreground: ''};
     this.themeRules.forEach((rule) => {
       // The best rule for a scope is the rule that is the longest prefix of the
       // scope (unless a perfect match exists in which case the perfect match is
@@ -367,7 +367,7 @@ export async function parseThemeFile(
       const addColor = (scope: string) => {
         if (seenScopes.has(scope))
           return;
-        rules.push({scope, foreground : textColor});
+        rules.push({scope, foreground: textColor});
         seenScopes.add(scope);
       };
       if (rule.scope instanceof Array) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -8,11 +8,11 @@ import {runTests} from 'vscode-test';
 
 // The entry point under VSCode - find the test files and run them in Mocha.
 export function run(): Promise<void> {
-  const mocha = new Mocha({ui : 'tdd', color : true});
+  const mocha = new Mocha({ui: 'tdd', color: true});
   const testsRoot = path.resolve(__dirname, '..');
 
   return new Promise((c, e) => {
-    glob('**/**.test.js', {cwd : testsRoot}, (err, files) => {
+    glob('**/**.test.js', {cwd: testsRoot}, (err, files) => {
       if (err) {
         return e(err);
       }

--- a/test/semantic-highlighting.test.ts
+++ b/test/semantic-highlighting.test.ts
@@ -13,9 +13,9 @@ suite('SemanticHighlighting Tests', () => {
     const getScopeRule = (scope: string) =>
         scopeColorRules.find((v) => v.scope === scope);
     assert.equal(scopeColorRules.length, 3);
-    assert.deepEqual(getScopeRule('a'), {scope : 'a', foreground : '#fff'});
-    assert.deepEqual(getScopeRule('b'), {scope : 'b', foreground : '#000'});
-    assert.deepEqual(getScopeRule('c'), {scope : 'c', foreground : '#bcd'});
+    assert.deepEqual(getScopeRule('a'), {scope: 'a', foreground: '#fff'});
+    assert.deepEqual(getScopeRule('b'), {scope: 'b', foreground: '#000'});
+    assert.deepEqual(getScopeRule('c'), {scope: 'c', foreground: '#bcd'});
   });
   test('Decodes tokens correctly', () => {
     const testCases: string[] = [
@@ -23,15 +23,15 @@ suite('SemanticHighlighting Tests', () => {
       'AAAAAAADAAkAAAAEAAEAAAAAAAoAAQAA'
     ];
     const expected = [
-      [ {character : 0, scopeIndex : 0, length : 1} ],
+      [{character: 0, scopeIndex: 0, length: 1}],
       [
-        {character : 0, scopeIndex : 9, length : 3},
-        {character : 4, scopeIndex : 0, length : 1}
+        {character: 0, scopeIndex: 9, length: 3},
+        {character: 4, scopeIndex: 0, length: 1}
       ],
       [
-        {character : 0, scopeIndex : 9, length : 3},
-        {character : 4, scopeIndex : 0, length : 1},
-        {character : 10, scopeIndex : 0, length : 1}
+        {character: 0, scopeIndex: 9, length: 3},
+        {character: 4, scopeIndex: 0, length: 1},
+        {character: 10, scopeIndex: 0, length: 1}
       ]
     ];
     testCases.forEach(
@@ -40,12 +40,12 @@ suite('SemanticHighlighting Tests', () => {
   });
   test('ScopeRules overrides for more specific themes', () => {
     const rules = [
-      {scope : 'variable.other.css', foreground : '1'},
-      {scope : 'variable.other', foreground : '2'},
-      {scope : 'storage', foreground : '3'},
-      {scope : 'storage.static', foreground : '4'},
-      {scope : 'storage', foreground : '5'},
-      {scope : 'variable.other.parameter', foreground : '6'},
+      {scope: 'variable.other.css', foreground: '1'},
+      {scope: 'variable.other', foreground: '2'},
+      {scope: 'storage', foreground: '3'},
+      {scope: 'storage.static', foreground: '4'},
+      {scope: 'storage', foreground: '5'},
+      {scope: 'variable.other.parameter', foreground: '6'},
     ];
     const tm = new semanticHighlighting.ThemeRuleMatcher(rules);
     assert.deepEqual(tm.getBestThemeRule('variable.other.cpp').scope,
@@ -62,8 +62,7 @@ suite('SemanticHighlighting Tests', () => {
   });
   test('Colorizer groups decorations correctly', async () => {
     const scopeTable = [
-      [ 'variable' ], [ 'entity.type.function' ],
-      [ 'entity.type.function.method' ]
+      ['variable'], ['entity.type.function'], ['entity.type.function.method']
     ];
     // Create the scope source ranges the highlightings should be highlighted
     // at. Assumes the scopes used are the ones in the "scopeTable" variable.
@@ -101,59 +100,59 @@ suite('SemanticHighlighting Tests', () => {
         return super.getDecorationRanges(fileUri);
       }
       // Override to make tests not depend on visible text editors.
-      getVisibleTextEditorUris() { return [ fileUri1, fileUri2 ]; }
+      getVisibleTextEditorUris() { return [fileUri1, fileUri2]; }
     }
     const highlighter = new MockHighlighter(scopeTable);
     const tm = new semanticHighlighting.ThemeRuleMatcher([
-      {scope : 'variable', foreground : '1'},
-      {scope : 'entity.type', foreground : '2'},
+      {scope: 'variable', foreground: '1'},
+      {scope: 'entity.type', foreground: '2'},
     ]);
     // Recolorizes when initialized.
     highlighter.highlight(fileUri1, []);
-    assert.deepEqual(highlighter.applicationUriHistory, [ fileUri1Str ]);
+    assert.deepEqual(highlighter.applicationUriHistory, [fileUri1Str]);
     highlighter.initialize(tm);
     assert.deepEqual(highlighter.applicationUriHistory,
-                     [ fileUri1Str, fileUri1Str, fileUri2Str ]);
+                     [fileUri1Str, fileUri1Str, fileUri2Str]);
     // Groups decorations into the scopes used.
     let highlightingsInLine: semanticHighlighting.SemanticHighlightingLine[] = [
       {
-        line : 1,
-        tokens : [
-          {character : 1, length : 2, scopeIndex : 1},
-          {character : 10, length : 2, scopeIndex : 2},
+        line: 1,
+        tokens: [
+          {character: 1, length: 2, scopeIndex: 1},
+          {character: 10, length: 2, scopeIndex: 2},
         ]
       },
       {
-        line : 2,
-        tokens : [
-          {character : 3, length : 2, scopeIndex : 1},
-          {character : 6, length : 2, scopeIndex : 1},
-          {character : 8, length : 2, scopeIndex : 2},
+        line: 2,
+        tokens: [
+          {character: 3, length: 2, scopeIndex: 1},
+          {character: 6, length: 2, scopeIndex: 1},
+          {character: 8, length: 2, scopeIndex: 2},
         ]
       },
     ];
 
     highlighter.highlight(fileUri1, highlightingsInLine);
     assert.deepEqual(highlighter.applicationUriHistory,
-                     [ fileUri1Str, fileUri1Str, fileUri2Str, fileUri1Str ]);
+                     [fileUri1Str, fileUri1Str, fileUri2Str, fileUri1Str]);
     assert.deepEqual(highlighter.getDecorationRanges(fileUri1),
                      createHighlightingScopeRanges(highlightingsInLine));
     // Keeps state separate between files.
     const highlightingsInLine1:
         semanticHighlighting.SemanticHighlightingLine = {
-      line : 1,
-      tokens : [
-        {character : 2, length : 1, scopeIndex : 0},
+      line: 1,
+      tokens: [
+        {character: 2, length: 1, scopeIndex: 0},
       ]
     };
-    highlighter.highlight(fileUri2, [ highlightingsInLine1 ]);
+    highlighter.highlight(fileUri2, [highlightingsInLine1]);
     assert.deepEqual(
         highlighter.applicationUriHistory,
-        [ fileUri1Str, fileUri1Str, fileUri2Str, fileUri1Str, fileUri2Str ]);
+        [fileUri1Str, fileUri1Str, fileUri2Str, fileUri1Str, fileUri2Str]);
     assert.deepEqual(highlighter.getDecorationRanges(fileUri2),
-                     createHighlightingScopeRanges([ highlightingsInLine1 ]));
+                     createHighlightingScopeRanges([highlightingsInLine1]));
     // Does full colorizations.
-    highlighter.highlight(fileUri1, [ highlightingsInLine1 ]);
+    highlighter.highlight(fileUri1, [highlightingsInLine1]);
     assert.deepEqual(highlighter.applicationUriHistory, [
       fileUri1Str, fileUri1Str, fileUri2Str, fileUri1Str, fileUri2Str,
       fileUri1Str
@@ -163,12 +162,12 @@ suite('SemanticHighlighting Tests', () => {
     assert.deepEqual(
         highlighter.getDecorationRanges(fileUri1),
         createHighlightingScopeRanges(
-            [ highlightingsInLine1, ...highlightingsInLine.slice(1) ]));
+            [highlightingsInLine1, ...highlightingsInLine.slice(1)]));
     // Closing a text document removes all highlightings for the file and no
     // other files.
     highlighter.removeFileHighlightings(fileUri1);
     assert.deepEqual(highlighter.getDecorationRanges(fileUri1), []);
     assert.deepEqual(highlighter.getDecorationRanges(fileUri2),
-                     createHighlightingScopeRanges([ highlightingsInLine1 ]));
+                     createHighlightingScopeRanges([highlightingsInLine1]));
   });
 });


### PR DESCRIPTION
I refuse to believe `{ key : value }` is actually intended, I think just nobody really uses LLVM style for JS.

See also http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20140127/098286.html