### PR TITLE
Support a subset of substitutions like ${workspaceRoot} in config.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ function substitute<T>(val: T): T {
   if (typeof val == 'string') {
     val = val.replace(/\$\{(.*?)\}/g, (match, name) => {
       const rep = replacement(name);
-      // If there's no replacement,available, keep the placeholder.
+      // If there's no replacement available, keep the placeholder.
       return (rep === null) ? match : rep;
     }) as unknown as T;
   } else if (Array.isArray(val))
@@ -45,12 +45,13 @@ function replacement(name: string): string|null {
   }
   if (name == 'cwd')
     return process.cwd();
-  if (name == 'execPath')
-    return vscode.env.appRoot;
-  if (name.startsWith('env:'))
-    return process.env[name.substr(4)] || '';
-  if (name.startsWith('config:')) {
-    const config = vscode.workspace.getConfiguration().get(name.substr(7));
+  const envPrefix = 'env:';
+  if (name.startsWith(envPrefix))
+    return process.env[name.substr(envPrefix.length)] || '';
+  const configPrefix = 'config:';
+  if (name.startsWith(configPrefix)) {
+    const config = vscode.workspace.getConfiguration().get(
+        name.substr(configPrefix.length));
     return (typeof config == 'string') ? config : null;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,15 +36,13 @@ function substitute<T>(val: T): T {
 // Subset of substitution variables that are most likely to be useful.
 // https://code.visualstudio.com/docs/editor/variables-reference
 function replacement(name: string): string|null {
-  if (name == 'workspaceRoot' || name == 'workspaceFolder') {
+  if (name == 'workspaceRoot' || name == 'workspaceFolder' || name == 'cwd') {
     if (vscode.workspace.rootPath !== undefined)
       return vscode.workspace.rootPath;
     if (vscode.window.activeTextEditor !== undefined)
       return path.dirname(vscode.window.activeTextEditor.document.uri.fsPath);
     return process.cwd();
   }
-  if (name == 'cwd')
-    return process.cwd();
   const envPrefix = 'env:';
   if (name.startsWith(envPrefix))
     return process.env[name.substr(envPrefix.length)] || '';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,53 @@
+import * as path from 'path';
+import * as process from 'process';
+import * as vscode from 'vscode';
+
+export function get<T>(key: string): T {
+  return substitute(vscode.workspace.getConfiguration('clangd').get(key));
+}
+
+export function update<T>(key: string, value: T,
+                          target?: vscode.ConfigurationTarget) {
+  return vscode.workspace.getConfiguration('clangd').update(key, value, target);
+}
+
+function substitute<T>(val: T): T {
+  if (typeof val == 'string') {
+    val = val.replace(/\$\{(.*?)\}/g, (match, name) => {
+      const rep = replacement(name);
+      return (rep === null) ? match : rep;
+    }) as unknown as T;
+  } else if (Array.isArray(val))
+    val = val.map((x) => substitute(x)) as unknown as T;
+  else if (typeof val == 'object') {
+    const result = {} as {[k: string]: any};
+    for (let [k, v] of Object.entries(val))
+      result[k] = substitute(v);
+    val = result as T;
+  }
+  return val;
+}
+
+// Subset of substitution variables that are most likely to be useful.
+// https://code.visualstudio.com/docs/editor/variables-reference
+function replacement(name: string): string|null {
+  if (name == 'workspaceRoot' || name == 'workspaceFolder') {
+    if (vscode.workspace.rootPath !== undefined)
+      return vscode.workspace.rootPath;
+    if (vscode.window.activeTextEditor !== undefined)
+      return path.dirname(vscode.window.activeTextEditor.document.uri.fsPath);
+    return process.cwd();
+  }
+  if (name == 'cwd')
+    return process.cwd();
+  if (name == 'execPath')
+    return vscode.env.appRoot;
+  if (name.startsWith('env:'))
+    return process.env[name.substr(4)] || '';
+  if (name.startsWith('config:')) {
+    const config = vscode.workspace.getConfiguration().get(name.substr(7));
+    return (typeof config == 'string') ? config : null;
+  }
+
+  return null;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import * as process from 'process';
 import * as vscode from 'vscode';
 
 // Gets the config value `clangd.<key>`. Applies ${variable} substitutions.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,20 +1,11 @@
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient';
 
+import * as config from './config';
 import * as fileStatus from './file-status';
 import * as install from './install';
 import * as semanticHighlighting from './semantic-highlighting';
 import * as switchSourceHeader from './switch-source-header';
-
-/**
- * Get an option from workspace configuration.
- * @param option name of the option (e.g. for clangd.path should be path)
- * @param defaultValue default value to return if option is not set
- */
-function getConfig<T>(option: string, defaultValue?: any): T {
-  const config = vscode.workspace.getConfiguration('clangd');
-  return config.get<T>(option, defaultValue);
-}
 
 class ClangdLanguageClient extends vscodelc.LanguageClient {
   // Override the default implementation for failed requests. The default
@@ -53,9 +44,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const clangd: vscodelc.Executable = {
     command: clangdPath,
-    args: getConfig<string[]>('arguments')
+    args: config.get<string[]>('arguments')
   };
-  const traceFile = getConfig<string>('trace');
+  const traceFile = config.get<string>('trace');
   if (!!traceFile) {
     const trace = {CLANGD_TRACE: traceFile};
     clangd.options = {env: {...process.env, ...trace}};
@@ -74,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ],
     initializationOptions: {
       clangdFileStatus: true,
-      fallbackFlags: getConfig<string[]>('fallbackFlags')
+      fallbackFlags: config.get<string[]>('fallbackFlags')
     },
     // Do not switch to output window when clangd returns output.
     revealOutputChannelOn: vscodelc.RevealOutputChannelOn.Never,
@@ -111,7 +102,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const client = new ClangdLanguageClient('Clang Language Server',
                                           serverOptions, clientOptions);
-  if (getConfig<boolean>('semanticHighlighting'))
+  if (config.get<boolean>('semanticHighlighting'))
     semanticHighlighting.activate(client, context);
   client.registerFeature(new EnableEditsNearCursorFeature);
   context.subscriptions.push(client.start());

--- a/src/install.ts
+++ b/src/install.ts
@@ -4,23 +4,22 @@
 import * as common from '@clangd/install';
 import AbortController from 'abort-controller';
 import * as vscode from 'vscode';
+import * as config from './config';
 
 // Returns the clangd path to be used, or null if clangd is not installed.
 export async function activate(context: vscode.ExtensionContext):
     Promise<string> {
-  const cfg = vscode.workspace.getConfiguration('clangd');
-  const ui = new UI(context, cfg);
+  const ui = new UI(context);
   context.subscriptions.push(vscode.commands.registerCommand(
       'clangd.install', async () => common.installLatest(ui)));
   context.subscriptions.push(vscode.commands.registerCommand(
       'clangd.update', async () => common.checkUpdates(true, ui)));
-  const status = await common.prepare(ui, cfg.get<boolean>('checkUpdates'));
+  const status = await common.prepare(ui, config.get<boolean>('checkUpdates'));
   return status.clangdPath;
 }
 
 class UI {
-  constructor(private context: vscode.ExtensionContext,
-              private config: vscode.WorkspaceConfiguration) {}
+  constructor(private context: vscode.ExtensionContext) {}
 
   get storagePath(): string { return this.context.globalStoragePath; }
   async choose(prompt: string, options: string[]): Promise<string|undefined> {
@@ -101,8 +100,7 @@ class UI {
       common.installLatest(this);
     }
     else if (response == dontCheck) {
-      this.config.update('checkUpdates', false,
-                         vscode.ConfigurationTarget.Global);
+      config.update('checkUpdates', false, vscode.ConfigurationTarget.Global);
     }
   }
 
@@ -113,8 +111,8 @@ class UI {
       common.installLatest(this);
   }
 
-  get clangdPath(): string { return this.config.get<string>('path')!; }
+  get clangdPath(): string { return config.get<string>('path'); }
   set clangdPath(p: string) {
-    this.config.update('path', p, vscode.ConfigurationTarget.Global);
+    config.update('path', p, vscode.ConfigurationTarget.Global);
   }
 }

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient';
 import * as vscodelct from 'vscode-languageserver-types';
+import * as config from './config';
 
 export function activate(client: vscodelc.LanguageClient,
                          context: vscode.ExtensionContext) {
@@ -90,9 +91,8 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
   }
 
   async loadCurrentTheme() {
-    const themeRuleMatcher = new ThemeRuleMatcher(
-        await loadTheme(vscode.workspace.getConfiguration('workbench')
-                            .get<string>('colorTheme')));
+    const themeRuleMatcher =
+        new ThemeRuleMatcher(await loadTheme(config.get<string>('colorTheme')));
     this.highlighter.initialize(themeRuleMatcher);
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
             "es2015.iterable",
             "es2015.promise",
             "es2015.symbol",
-            "es2016.array.include"
+            "es2016.array.include",
+            "es2017.object"
         ],
         "sourceMap": true,
         "rootDir": ".",


### PR DESCRIPTION
VSCode doesn't currently provide any APIs for extensions to expand these.
So we pick a few that seem useful and are easy to substitute.

Fixes https://github.com/clangd/vscode-clangd/issues/22