### PR TITLE
Interpret clangd.path relative to ${cwd} if it has a slash

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -107,8 +107,14 @@ class UI {
   }
 
   async promptInstall(version: string) {
-    const message = 'The clangd language server was not found on your PATH.\n' +
-                    `Would you like to download and install clangd ${version}?`;
+    const p = this.clangdPath;
+    let message = '';
+    if (p.indexOf(path.sep) < 0) {
+      message += 'The ${p} language server was not found on your PATH.\n';
+    } else {
+      message += `The clangd binary '${p}' was not found.\n`;
+    }
+    message += `Would you like to download and install clangd ${version}?`;
     if (await vscode.window.showInformationMessage(message, 'Install'))
       common.installLatest(this);
   }

--- a/src/install.ts
+++ b/src/install.ts
@@ -3,7 +3,9 @@
 
 import * as common from '@clangd/install';
 import AbortController from 'abort-controller';
+import * as path from 'path';
 import * as vscode from 'vscode';
+
 import * as config from './config';
 
 // Returns the clangd path to be used, or null if clangd is not installed.
@@ -111,7 +113,15 @@ class UI {
       common.installLatest(this);
   }
 
-  get clangdPath(): string { return config.get<string>('path'); }
+  get clangdPath(): string {
+    let p = config.get<string>('path');
+    // Backwards compatibility: if it's a relative path with a slash, interpret
+    // relative to project root.
+    if (!path.isAbsolute(p) && p.indexOf(path.sep) != -1 &&
+        vscode.workspace.rootPath !== undefined)
+      p = path.join(vscode.workspace.rootPath, p);
+    return p;
+  }
   set clangdPath(p: string) {
     config.update('path', p, vscode.ConfigurationTarget.Global);
   }


### PR DESCRIPTION
This doesn't make a lot of sense, but seems to be backwards-compat behavior.

Fixes #22