### PR TITLE
Add "clangd.restart" command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,10 @@
             {
                 "command": "clangd.activate",
                 "title": "Manually activate clangd extension"
+            },
+            {
+                "command": "clangd.restart",
+                "title": "Restart the clangd language server"
             }
         ],
         "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,17 @@ class ClangdLanguageClient extends vscodelc.LanguageClient {
     // Call default implementation.
     super.logFailedRequest(rpcReply, error);
   }
+
+  activate() {
+    this.dispose();
+    this.startDisposable = this.start();
+  }
+
+  dispose() {
+    if (this.startDisposable)
+      this.startDisposable.dispose();
+  }
+  private startDisposable: vscodelc.Disposable;
 }
 
 class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
@@ -102,10 +113,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const client = new ClangdLanguageClient('Clang Language Server',
                                           serverOptions, clientOptions);
+  context.subscriptions.push(vscode.Disposable.from(client));
   if (config.get<boolean>('semanticHighlighting'))
     semanticHighlighting.activate(client, context);
   client.registerFeature(new EnableEditsNearCursorFeature);
-  context.subscriptions.push(client.start());
+  client.activate();
   console.log('Clang Language Server is now active!');
   fileStatus.activate(client, context);
   switchSourceHeader.activate(client, context);
@@ -116,6 +128,6 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
         await client.stop();
-        context.subscriptions.push(client.start());
+        client.activate();
       }));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,4 +113,9 @@ export async function activate(context: vscode.ExtensionContext) {
   // "command is not registered" error.
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.activate', async () => {}));
+  context.subscriptions.push(
+      vscode.commands.registerCommand('clangd.restart', async () => {
+        await client.stop();
+        context.subscriptions.push(client.start());
+      }));
 }


### PR DESCRIPTION
Similar to YCM's "RestartServer" command.

If clangd crashes, vscode will try to restart clangd up to 5 times. After that, there is no way to restart clangd except reloading the vscode window. However, reloading the vscode window will lose the whole working context in vscode, especially you are running programs in the integrated terminal.

"clangd.restart" command will restart clangd server **without** reloading the vscode window.