### PR TITLE
support proposed official semantic highlighting API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1555,25 +1555,25 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "6.0.0-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.4.tgz",
-            "integrity": "sha512-nIXUeSMKfqvqSG75s1JuUy0UgjE3d0NERjGz7AUGDFXX0/roVUEbaio5VBdus30nty8v0FCf/6MbCSrH5RybcQ=="
+            "version": "6.0.0-next.5",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.5.tgz",
+            "integrity": "sha512-IAgsltQPwg/pXOPsdXgbUTCaO9VSKZwirZN5SGtkdYQ/R3VjeC4v00WTVvoNayWMZpoC3O9u0ogqmsKzKhVasQ=="
         },
         "vscode-languageclient": {
-            "version": "7.0.0-next.8",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.8.tgz",
-            "integrity": "sha512-qgQBImLm24tjhvc42YbLLRYWibwSgccUruy0GhVOr69BZRfT3CkMeeQfjIdumrfCCYPu/vPdJ6KjtAYamBCESw==",
+            "version": "7.0.0-next.9",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.9.tgz",
+            "integrity": "sha512-lFO+rN/i72CM2va6iKXq1lD7pJg8J93KEXf0w0boWVqU+DJhWzLrV3pXl8Xk1nCv//qOAyhlc/nx2KZCTeRF/A==",
             "requires": {
                 "semver": "^6.3.0",
-                "vscode-languageserver-protocol": "3.16.0-next.6"
+                "vscode-languageserver-protocol": "3.16.0-next.7"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0-next.6",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.6.tgz",
-            "integrity": "sha512-tW8LMFBBr6WJ33mzYAjiLTu/4tch9nvJ+rBhUNzJ8X1zNR39vj8CV3FsnrxzAqvOB+qBWEOQa0tjupW1mNo2GQ==",
+            "version": "3.16.0-next.7",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.7.tgz",
+            "integrity": "sha512-tOjrg+K3RddJ547zpC9/LAgTbzadkPuHlqJFFWIcKjVhiJOh73XyY+Ngcu9wukGaTsuSGjJ0W8rlmwanixa0FQ==",
             "requires": {
-                "vscode-jsonrpc": "6.0.0-next.4",
+                "vscode-jsonrpc": "6.0.0-next.5",
                 "vscode-languageserver-types": "3.16.0-next.3"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1555,32 +1555,32 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-            "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+            "version": "6.0.0-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.4.tgz",
+            "integrity": "sha512-nIXUeSMKfqvqSG75s1JuUy0UgjE3d0NERjGz7AUGDFXX0/roVUEbaio5VBdus30nty8v0FCf/6MbCSrH5RybcQ=="
         },
         "vscode-languageclient": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.1.0.tgz",
-            "integrity": "sha512-Tcp0VoOaa0YzxL4nEfK9tsmcy76Eo8jNLvFQZwh2c8oMm02luL8uGYPLQNAiZ3XGgegfcwiQFZMqbW7DNV0vxA==",
+            "version": "7.0.0-next.8",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.8.tgz",
+            "integrity": "sha512-qgQBImLm24tjhvc42YbLLRYWibwSgccUruy0GhVOr69BZRfT3CkMeeQfjIdumrfCCYPu/vPdJ6KjtAYamBCESw==",
             "requires": {
                 "semver": "^6.3.0",
-                "vscode-languageserver-protocol": "^3.15.2"
+                "vscode-languageserver-protocol": "3.16.0-next.6"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.15.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.2.tgz",
-            "integrity": "sha512-GdL05JKOgZ76RDg3suiGCl9enESM7iQgGw4x93ibTh4sldvZmakHmTeZ4iUApPPGKf6O3OVBtrsksBXnHYaxNg==",
+            "version": "3.16.0-next.6",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.6.tgz",
+            "integrity": "sha512-tW8LMFBBr6WJ33mzYAjiLTu/4tch9nvJ+rBhUNzJ8X1zNR39vj8CV3FsnrxzAqvOB+qBWEOQa0tjupW1mNo2GQ==",
             "requires": {
-                "vscode-jsonrpc": "^5.0.1",
-                "vscode-languageserver-types": "3.15.1"
+                "vscode-jsonrpc": "6.0.0-next.4",
+                "vscode-languageserver-types": "3.16.0-next.3"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
-            "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
+            "version": "3.16.0-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.3.tgz",
+            "integrity": "sha512-s/z5ZqSe7VpoXJ6JQcvwRiPPA3nG0nAcJ/HH03zoU6QaFfnkcgPK+HshC3WKPPnC2G08xA0iRB6h7kmyBB5Adg=="
         },
         "vscode-test": {
             "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.41.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
-            "integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
+            "integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
             "dev": true
         },
         "abort-controller": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "C and C++ completion, navigation, and insights",
     "version": "0.1.6",
     "publisher": "llvm-vs-code-extensions",
+    "license": "MIT",
     "homepage": "https://clangd.llvm.org/",
     "icon": "icon.png",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "dependencies": {
         "abort-controller": "^3.0.0",
         "jsonc-parser": "^2.1.0",
-        "vscode-languageclient": "6.1.0",
-        "vscode-languageserver-types": "^3.15.1",
+        "vscode-languageclient": "7.0.0-next.8",
+        "vscode-languageserver-types": "3.16.0-next.3",
         "@clangd/install": "0.1.3"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dependencies": {
         "abort-controller": "^3.0.0",
         "jsonc-parser": "^2.1.0",
-        "vscode-languageclient": "7.0.0-next.8",
+        "vscode-languageclient": "7.0.0-next.9",
         "vscode-languageserver-types": "3.16.0-next.3",
         "@clangd/install": "0.1.3"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://clangd.llvm.org/",
     "icon": "icon.png",
     "engines": {
-        "vscode": "^1.41.0"
+        "vscode": "^1.46.0"
     },
     "categories": [
         "Programming Languages",
@@ -52,7 +52,7 @@
         "@types/glob": "^7.1.1",
         "@types/mocha": "^7.0.2",
         "@types/node": "^6.0.40",
-        "@types/vscode": "1.41.*",
+        "@types/vscode": "1.46.*",
         "clang-format": "1.4.0",
         "glob": "^7.1.4",
         "mocha": "^7.1.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as vscodelc from 'vscode-languageclient';
+import * as vscodelc from 'vscode-languageclient/node';
 
 import * as config from './config';
 import * as fileStatus from './file-status';
@@ -16,12 +16,14 @@ class ClangdLanguageClient extends vscodelc.LanguageClient {
   //
   // For user-interactive operations (e.g. applyFixIt, applyTweaks), we will
   // prompt up the failure to users.
-  logFailedRequest(rpcReply: vscodelc.RPCMessageType, error: any) {
+
+  handleFailedRequest<T>(type: vscodelc.MessageSignature, error: any,
+                         defaultValue: T): T {
     if (error instanceof vscodelc.ResponseError &&
-        rpcReply.method === 'workspace/executeCommand')
+        type.method === 'workspace/executeCommand')
       vscode.window.showErrorMessage(error.message);
-    // Call default implementation.
-    super.logFailedRequest(rpcReply, error);
+
+    return super.handleFailedRequest(type, error, defaultValue);
   }
 
   activate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,8 +103,8 @@ export async function activate(context: vscode.ExtensionContext) {
             let list = await next(document, position, context, token);
             let items = (Array.isArray(list) ? list : list.items).map(item => {
               // Gets the prefix used by VSCode when doing fuzzymatch.
-              let prefix =
-                  document.getText(new vscode.Range(item.range.start, position))
+              let prefix = document.getText(new vscode.Range(
+                  (item.range as vscode.Range).start, position))
               if (prefix)
               item.filterText = prefix + '_' + item.filterText;
               return item;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.Disposable.from(client));
   if (config.get<boolean>('semanticHighlighting'))
     semanticHighlighting.activate(client, context);
+  client.registerProposedFeatures(); // enables LSP 3.16 semantic highlighting
   client.registerFeature(new EnableEditsNearCursorFeature);
   typeHierarchy.activate(client, context);
   client.activate();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,6 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.Disposable.from(client));
   if (config.get<boolean>('semanticHighlighting'))
     semanticHighlighting.activate(client, context);
-  client.registerProposedFeatures(); // enables LSP 3.16 semantic highlighting
   client.registerFeature(new EnableEditsNearCursorFeature);
   typeHierarchy.activate(client, context);
   client.activate();

--- a/src/file-status.ts
+++ b/src/file-status.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as vscodelc from 'vscode-languageclient';
+import * as vscodelc from 'vscode-languageclient/node';
 
 export function activate(client: vscodelc.LanguageClient,
                          context: vscode.ExtensionContext) {

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as jsonc from 'jsonc-parser';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as vscodelc from 'vscode-languageclient';
+import * as vscodelc from 'vscode-languageclient/node';
 import * as vscodelct from 'vscode-languageserver-types';
 
 export function activate(client: vscodelc.LanguageClient,

--- a/src/switch-source-header.ts
+++ b/src/switch-source-header.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as vscodelc from 'vscode-languageclient';
+import * as vscodelc from 'vscode-languageclient/node';
 
 export function activate(client: vscodelc.LanguageClient,
                          context: vscode.ExtensionContext) {

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -123,7 +123,7 @@ class TypeHierarchyProvider implements
     const range =
         this.client.protocol2CodeConverter.asRange(item.selectionRange);
     const doc = await vscode.workspace.openTextDocument(uri);
-    let editor: vscode.TextEditor;
+    let editor : vscode.TextEditor | undefined;
     if (doc) {
       editor = await vscode.window.showTextDocument(doc, undefined);
     } else {
@@ -145,7 +145,7 @@ class TypeHierarchyProvider implements
     return new TypeHierarchyTreeItem(element);
   }
 
-  public getParent(element: TypeHierarchyItem): TypeHierarchyItem {
+  public getParent(element: TypeHierarchyItem): TypeHierarchyItem | null {
     // This function is only implemented so that VSCode lets us call
     // this.treeView.reveal(). Since we only ever call reveal() on the root,
     // which has no parent, it's fine to always return null.

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -86,7 +86,7 @@ class TypeHierarchyProvider implements
     vscode.TreeDataProvider<TypeHierarchyItem> {
 
   private _onDidChangeTreeData =
-      new vscode.EventEmitter<TypeHierarchyItem | null>();
+      new vscode.EventEmitter<TypeHierarchyItem|null>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
   private root?: TypeHierarchyItem;

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -123,7 +123,7 @@ class TypeHierarchyProvider implements
     const range =
         this.client.protocol2CodeConverter.asRange(item.selectionRange);
     const doc = await vscode.workspace.openTextDocument(uri);
-    let editor : vscode.TextEditor | undefined;
+    let editor: vscode.TextEditor|undefined;
     if (doc) {
       editor = await vscode.window.showTextDocument(doc, undefined);
     } else {
@@ -145,7 +145,7 @@ class TypeHierarchyProvider implements
     return new TypeHierarchyTreeItem(element);
   }
 
-  public getParent(element: TypeHierarchyItem): TypeHierarchyItem | null {
+  public getParent(element: TypeHierarchyItem): TypeHierarchyItem|null {
     // This function is only implemented so that VSCode lets us call
     // this.treeView.reveal(). Since we only ever call reveal() on the root,
     // which has no parent, it's fine to always return null.

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -6,7 +6,7 @@
 // symbol under the cursor, which are visualized in a tree view.
 
 import * as vscode from 'vscode';
-import * as vscodelc from 'vscode-languageclient';
+import * as vscodelc from 'vscode-languageclient/node';
 
 export function activate(client: vscodelc.LanguageClient,
                          context: vscode.ExtensionContext) {

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -85,10 +85,9 @@ class TypeHierarchyTreeItem extends vscode.TreeItem {
 class TypeHierarchyProvider implements
     vscode.TreeDataProvider<TypeHierarchyItem> {
 
-  private _onDidChangeTreeData: vscode.EventEmitter<TypeHierarchyItem> =
-      new vscode.EventEmitter();
-  readonly onDidChangeTreeData: vscode.Event<TypeHierarchyItem> =
-      this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData =
+      new vscode.EventEmitter<TypeHierarchyItem | null>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
   private root?: TypeHierarchyItem;
   private direction: TypeHierarchyDirection;
@@ -139,7 +138,7 @@ class TypeHierarchyProvider implements
 
   public async setDirection(direction: TypeHierarchyDirection) {
     this.direction = direction;
-    this._onDidChangeTreeData.fire();
+    this._onDidChangeTreeData.fire(null);
   }
 
   public getTreeItem(element: TypeHierarchyItem): vscode.TreeItem {
@@ -200,7 +199,7 @@ class TypeHierarchyProvider implements
     });
     if (item) {
       this.root = item;
-      this._onDidChangeTreeData.fire();
+      this._onDidChangeTreeData.fire(null);
 
       // This focuses the "explorer" view container which contains the
       // type hierarchy view.
@@ -220,6 +219,6 @@ class TypeHierarchyProvider implements
         'setContext', 'extension.vscode-clangd.typeHierarchyVisible', false);
 
     this.root = undefined;
-    this._onDidChangeTreeData.fire();
+    this._onDidChangeTreeData.fire(null);
   }
 }


### PR DESCRIPTION
For the record, this seems to be enough to enable support for the new semantic highlighting.
More of an RFC. It needs to be checked what [changed between LSP client 6.1.3 and the final version](https://github.com/microsoft/vscode-languageserver-node/commits/master/protocol/src/common/protocol.semanticTokens.proposed.ts) and which state will be included in the clangd-11 release (v10 falls back to the old implementation).
Even works in non-insiders vscode @sam-mccall.

It's also unclear if
```diff
-        "vscode": "^1.41.0"
+        "vscode": "^1.44.0"

-        "@types/vscode": "1.41.*",
+        "@types/vscode": "1.44.*",
```
offers anything due to https://code.visualstudio.com/updates/v1_44#_semantic-tokens-provider-api