### PR TITLE
Mark clangd.path as scope=machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
                 "clangd.path": {
                     "type": "string",
                     "default": "clangd",
+                    "scope": "machine",
                     "description": "The path to clangd executable, e.g.: /usr/bin/clangd."
                 },
                 "clangd.arguments": {


### PR DESCRIPTION
When overridden, this tends to be machine-specific, especially when the
path is produced by autoinstall.
This change of scope should cause vscode to update the remote settings
rather than the (cross-machine) user ones, in the autoinstall flow.