### PR TITLE
Use scope=machine-overridable for clangd.path

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
                 "clangd.path": {
                     "type": "string",
                     "default": "clangd",
-                    "scope": "machine",
+                    "scope": "machine-overridable",
                     "description": "The path to clangd executable, e.g.: /usr/bin/clangd."
                 },
                 "clangd.arguments": {


### PR DESCRIPTION
This allows the setting to continue to be overridable per-workspace.

Fixes https://github.com/clangd/vscode-clangd/issues/64