### PR TITLE
Re-read config when restarting server

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -1,0 +1,156 @@
+import * as vscode from 'vscode';
+import * as vscodelc from 'vscode-languageclient/node';
+
+import * as config from './config';
+import * as configFileWatcher from './config-file-watcher';
+import * as fileStatus from './file-status';
+import * as install from './install';
+import * as semanticHighlighting from './semantic-highlighting';
+import * as switchSourceHeader from './switch-source-header';
+import * as typeHierarchy from './type-hierarchy';
+
+class ClangdLanguageClient extends vscodelc.LanguageClient {
+  // Override the default implementation for failed requests. The default
+  // behavior is just to log failures in the output panel, however output panel
+  // is designed for extension debugging purpose, normal users will not open it,
+  // thus when the failure occurs, normal users doesn't know that.
+  //
+  // For user-interactive operations (e.g. applyFixIt, applyTweaks), we will
+  // prompt up the failure to users.
+
+  handleFailedRequest<T>(type: vscodelc.MessageSignature, error: any,
+                         defaultValue: T): T {
+    if (error instanceof vscodelc.ResponseError &&
+        type.method === 'workspace/executeCommand')
+      vscode.window.showErrorMessage(error.message);
+
+    return super.handleFailedRequest(type, error, defaultValue);
+  }
+
+  activate() {
+    this.dispose();
+    this.startDisposable = this.start();
+  }
+
+  dispose() {
+    if (this.startDisposable)
+      this.startDisposable.dispose();
+  }
+  private startDisposable: vscodelc.Disposable;
+}
+
+class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
+  initialize() {}
+  fillClientCapabilities(capabilities: vscodelc.ClientCapabilities): void {
+    const extendedCompletionCapabilities: any =
+        capabilities.textDocument.completion;
+    extendedCompletionCapabilities.editsNearCursor = true;
+  }
+}
+
+export class ClangdContext implements vscode.Disposable {
+  subscriptions: vscode.Disposable[] = [];
+  client: ClangdLanguageClient;
+
+  async activate(globalStoragePath: string,
+                 outputChannel: vscode.OutputChannel) {
+    const clangdPath = await install.activate(this, globalStoragePath);
+    if (!clangdPath)
+      return;
+
+    const clangd: vscodelc.Executable = {
+      command: clangdPath,
+      args: config.get<string[]>('arguments')
+    };
+    const traceFile = config.get<string>('trace');
+    if (!!traceFile) {
+      const trace = {CLANGD_TRACE: traceFile};
+      clangd.options = {env: {...process.env, ...trace}};
+    }
+    const serverOptions: vscodelc.ServerOptions = clangd;
+
+    const clientOptions: vscodelc.LanguageClientOptions = {
+      // Register the server for c-family and cuda files.
+      documentSelector: [
+        {scheme: 'file', language: 'c'},
+        {scheme: 'file', language: 'cpp'},
+        // CUDA is not supported by vscode, but our extension does supports it.
+        {scheme: 'file', language: 'cuda'},
+        {scheme: 'file', language: 'objective-c'},
+        {scheme: 'file', language: 'objective-cpp'},
+      ],
+      initializationOptions: {
+        clangdFileStatus: true,
+        fallbackFlags: config.get<string[]>('fallbackFlags')
+      },
+      outputChannel: outputChannel,
+      // Do not switch to output window when clangd returns output.
+      revealOutputChannelOn: vscodelc.RevealOutputChannelOn.Never,
+
+      // We hack up the completion items a bit to prevent VSCode from re-ranking
+      // and throwing away all our delicious signals like type information.
+      //
+      // VSCode sorts by (fuzzymatch(prefix, item.filterText), item.sortText)
+      // By adding the prefix to the beginning of the filterText, we get a
+      // perfect
+      // fuzzymatch score for every item.
+      // The sortText (which reflects clangd ranking) breaks the tie.
+      // This also prevents VSCode from filtering out any results due to the
+      // differences in how fuzzy filtering is applies, e.g. enable dot-to-arrow
+      // fixes in completion.
+      //
+      // We also mark the list as incomplete to force retrieving new rankings.
+      // See https://github.com/microsoft/language-server-protocol/issues/898
+      middleware: {
+        provideCompletionItem: async (document, position, context, token,
+                                      next) => {
+          let list = await next(document, position, context, token);
+          let items = (Array.isArray(list) ? list : list.items).map(item => {
+            // Gets the prefix used by VSCode when doing fuzzymatch.
+            let prefix = document.getText(
+                new vscode.Range((item.range as vscode.Range).start, position))
+            if (prefix)
+            item.filterText = prefix + '_' + item.filterText;
+            return item;
+          })
+          return new vscode.CompletionList(items, /*isIncomplete=*/ true);
+        },
+        // VSCode applies fuzzy match only on the symbol name, thus it throws
+        // away
+        // all results if query token is a prefix qualified name.
+        // By adding the containerName to the symbol name, it prevents VSCode
+        // from
+        // filtering out any results, e.g. enable workspaceSymbols for qualified
+        // symbols.
+        provideWorkspaceSymbols: async (query, token, next) => {
+          let symbols = await next(query, token);
+          return symbols.map(symbol => {
+            if (symbol.containerName)
+              symbol.name = `${symbol.containerName}::${symbol.name}`;
+            // Always clean the containerName to avoid displaying it twice.
+            symbol.containerName = '';
+            return symbol;
+          })
+        },
+      },
+    };
+
+    this.client = new ClangdLanguageClient('Clang Language Server',
+                                           serverOptions, clientOptions);
+    this.subscriptions.push(vscode.Disposable.from(this.client));
+    if (config.get<boolean>('semanticHighlighting'))
+      semanticHighlighting.activate(this.client, this);
+    this.client.registerFeature(new EnableEditsNearCursorFeature);
+    typeHierarchy.activate(this.client, this);
+    this.client.activate();
+    console.log('Clang Language Server is now active!');
+    fileStatus.activate(this.client, this);
+    switchSourceHeader.activate(this.client, this);
+    configFileWatcher.activate(this);
+  }
+
+  dispose() {
+    this.subscriptions.forEach((d) => { d.dispose(); });
+    this.subscriptions = []
+  }
+}

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -139,13 +139,13 @@ export class ClangdContext implements vscode.Disposable {
                                            serverOptions, clientOptions);
     this.subscriptions.push(vscode.Disposable.from(this.client));
     if (config.get<boolean>('semanticHighlighting'))
-      semanticHighlighting.activate(this.client, this);
+      semanticHighlighting.activate(this);
     this.client.registerFeature(new EnableEditsNearCursorFeature);
-    typeHierarchy.activate(this.client, this);
+    typeHierarchy.activate(this);
     this.client.activate();
     console.log('Clang Language Server is now active!');
-    fileStatus.activate(this.client, this);
-    switchSourceHeader.activate(this.client, this);
+    fileStatus.activate(this);
+    switchSourceHeader.activate(this);
     configFileWatcher.activate(this);
   }
 

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -26,17 +26,6 @@ class ClangdLanguageClient extends vscodelc.LanguageClient {
 
     return super.handleFailedRequest(type, error, defaultValue);
   }
-
-  activate() {
-    this.dispose();
-    this.startDisposable = this.start();
-  }
-
-  dispose() {
-    if (this.startDisposable)
-      this.startDisposable.dispose();
-  }
-  private startDisposable: vscodelc.Disposable;
 }
 
 class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
@@ -137,12 +126,11 @@ export class ClangdContext implements vscode.Disposable {
 
     this.client = new ClangdLanguageClient('Clang Language Server',
                                            serverOptions, clientOptions);
-    this.subscriptions.push(vscode.Disposable.from(this.client));
     if (config.get<boolean>('semanticHighlighting'))
       semanticHighlighting.activate(this);
     this.client.registerFeature(new EnableEditsNearCursorFeature);
     typeHierarchy.activate(this);
-    this.client.activate();
+    this.subscriptions.push(this.client.start());
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);
     switchSourceHeader.activate(this);

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 
+import {ClangdContext} from './clangd-context';
 import * as config from './config';
 
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: ClangdContext) {
   if (config.get<string>('onConfigChanged') != 'ignore') {
     const watcher = new ConfigFileWatcher(context);
   }
@@ -11,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
 class ConfigFileWatcher {
   private databaseWatcher: vscode.FileSystemWatcher = undefined;
 
-  constructor(private context: vscode.ExtensionContext) {
+  constructor(private context: ClangdContext) {
     this.createFileSystemWatcher();
     context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(
         () => { this.createFileSystemWatcher(); }));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,51 +1,18 @@
 import * as vscode from 'vscode';
-import * as vscodelc from 'vscode-languageclient/node';
 
-import * as config from './config';
-import * as configFileWatcher from './config-file-watcher';
-import * as fileStatus from './file-status';
-import * as install from './install';
-import * as semanticHighlighting from './semantic-highlighting';
-import * as switchSourceHeader from './switch-source-header';
-import * as typeHierarchy from './type-hierarchy';
+import {ClangdContext} from './clangd-context';
 
-class ClangdLanguageClient extends vscodelc.LanguageClient {
-  // Override the default implementation for failed requests. The default
-  // behavior is just to log failures in the output panel, however output panel
-  // is designed for extension debugging purpose, normal users will not open it,
-  // thus when the failure occurs, normal users doesn't know that.
-  //
-  // For user-interactive operations (e.g. applyFixIt, applyTweaks), we will
-  // prompt up the failure to users.
+let clangdContext: ClangdContext|null;
 
-  handleFailedRequest<T>(type: vscodelc.MessageSignature, error: any,
-                         defaultValue: T): T {
-    if (error instanceof vscodelc.ResponseError &&
-        type.method === 'workspace/executeCommand')
-      vscode.window.showErrorMessage(error.message);
-
-    return super.handleFailedRequest(type, error, defaultValue);
-  }
-
-  activate() {
-    this.dispose();
-    this.startDisposable = this.start();
-  }
-
-  dispose() {
-    if (this.startDisposable)
-      this.startDisposable.dispose();
-  }
-  private startDisposable: vscodelc.Disposable;
+async function startClient(globalStoragePath: string,
+                           outputChannel: vscode.OutputChannel) {
+  clangdContext = new ClangdContext;
+  clangdContext.activate(globalStoragePath, outputChannel);
 }
 
-class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
-  initialize() {}
-  fillClientCapabilities(capabilities: vscodelc.ClientCapabilities): void {
-    const extendedCompletionCapabilities: any =
-        capabilities.textDocument.completion;
-    extendedCompletionCapabilities.editsNearCursor = true;
-  }
+async function stopClient() {
+  await clangdContext?.dispose();
+  clangdContext = null;
 }
 
 /**
@@ -53,102 +20,21 @@ class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
  *  activated the very first time a command is executed.
  */
 export async function activate(context: vscode.ExtensionContext) {
-  const clangdPath = await install.activate(context);
-  if (!clangdPath)
-    return;
+  const outputChannel =
+      vscode.window.createOutputChannel('Clangd Language Server');
+  context.subscriptions.push(outputChannel);
 
-  const clangd: vscodelc.Executable = {
-    command: clangdPath,
-    args: config.get<string[]>('arguments')
-  };
-  const traceFile = config.get<string>('trace');
-  if (!!traceFile) {
-    const trace = {CLANGD_TRACE: traceFile};
-    clangd.options = {env: {...process.env, ...trace}};
-  }
-  const serverOptions: vscodelc.ServerOptions = clangd;
-
-  const clientOptions: vscodelc.LanguageClientOptions = {
-    // Register the server for c-family and cuda files.
-    documentSelector: [
-      {scheme: 'file', language: 'c'},
-      {scheme: 'file', language: 'cpp'},
-      // CUDA is not supported by vscode, but our extension does supports it.
-      {scheme: 'file', language: 'cuda'},
-      {scheme: 'file', language: 'objective-c'},
-      {scheme: 'file', language: 'objective-cpp'},
-    ],
-    initializationOptions: {
-      clangdFileStatus: true,
-      fallbackFlags: config.get<string[]>('fallbackFlags')
-    },
-    // Do not switch to output window when clangd returns output.
-    revealOutputChannelOn: vscodelc.RevealOutputChannelOn.Never,
-
-    // We hack up the completion items a bit to prevent VSCode from re-ranking
-    // and throwing away all our delicious signals like type information.
-    //
-    // VSCode sorts by (fuzzymatch(prefix, item.filterText), item.sortText)
-    // By adding the prefix to the beginning of the filterText, we get a perfect
-    // fuzzymatch score for every item.
-    // The sortText (which reflects clangd ranking) breaks the tie.
-    // This also prevents VSCode from filtering out any results due to the
-    // differences in how fuzzy filtering is applies, e.g. enable dot-to-arrow
-    // fixes in completion.
-    //
-    // We also mark the list as incomplete to force retrieving new rankings.
-    // See https://github.com/microsoft/language-server-protocol/issues/898
-    middleware: {
-      provideCompletionItem: async (document, position, context, token,
-                                    next) => {
-        let list = await next(document, position, context, token);
-        let items = (Array.isArray(list) ? list : list.items).map(item => {
-          // Gets the prefix used by VSCode when doing fuzzymatch.
-          let prefix = document.getText(
-              new vscode.Range((item.range as vscode.Range).start, position))
-          if (prefix)
-          item.filterText = prefix + '_' + item.filterText;
-          return item;
-        })
-        return new vscode.CompletionList(items, /*isIncomplete=*/ true);
-      },
-      // VSCode applies fuzzy match only on the symbol name, thus it throws away
-      // all results if query token is a prefix qualified name.
-      // By adding the containerName to the symbol name, it prevents VSCode from
-      // filtering out any results, e.g. enable workspaceSymbols for qualified
-      // symbols.
-      provideWorkspaceSymbols: async (query, token, next) => {
-        let symbols = await next(query, token);
-        return symbols.map(symbol => {
-          if (symbol.containerName)
-            symbol.name = `${symbol.containerName}::${symbol.name}`;
-          // Always clean the containerName to avoid displaying it twice.
-          symbol.containerName = '';
-          return symbol;
-        })
-      },
-    },
-  };
-
-  const client = new ClangdLanguageClient('Clang Language Server',
-                                          serverOptions, clientOptions);
-  context.subscriptions.push(vscode.Disposable.from(client));
-  if (config.get<boolean>('semanticHighlighting'))
-    semanticHighlighting.activate(client, context);
-  client.registerFeature(new EnableEditsNearCursorFeature);
-  typeHierarchy.activate(client, context);
-  client.activate();
-  console.log('Clang Language Server is now active!');
-  fileStatus.activate(client, context);
-  switchSourceHeader.activate(client, context);
-  configFileWatcher.activate(context);
   // An empty place holder for the activate command, otherwise we'll get an
   // "command is not registered" error.
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.activate', async () => {}));
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
-        await client.stop();
-        client.activate();
+        await stopClient();
+        await startClient(context.globalStoragePath, outputChannel);
       }));
+
+  startClient(context.globalStoragePath, outputChannel);
 }
+
+export function deactivate() { stopClient(); }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,19 +2,6 @@ import * as vscode from 'vscode';
 
 import {ClangdContext} from './clangd-context';
 
-let clangdContext: ClangdContext|null;
-
-async function startClient(globalStoragePath: string,
-                           outputChannel: vscode.OutputChannel) {
-  clangdContext = new ClangdContext;
-  clangdContext.activate(globalStoragePath, outputChannel);
-}
-
-async function stopClient() {
-  await clangdContext?.dispose();
-  clangdContext = null;
-}
-
 /**
  *  This method is called when the extension is activated. The extension is
  *  activated the very first time a command is executed.
@@ -24,17 +11,18 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window.createOutputChannel('Clangd Language Server');
   context.subscriptions.push(outputChannel);
 
+  const clangdContext = new ClangdContext;
+  context.subscriptions.push(clangdContext);
+
   // An empty place holder for the activate command, otherwise we'll get an
   // "command is not registered" error.
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.activate', async () => {}));
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
-        await stopClient();
-        await startClient(context.globalStoragePath, outputChannel);
+        await clangdContext.dispose();
+        await clangdContext.activate(context.globalStoragePath, outputChannel);
       }));
 
-  startClient(context.globalStoragePath, outputChannel);
+  await clangdContext.activate(context.globalStoragePath, outputChannel);
 }
-
-export function deactivate() { stopClient(); }

--- a/src/file-status.ts
+++ b/src/file-status.ts
@@ -3,16 +3,15 @@ import * as vscodelc from 'vscode-languageclient/node';
 
 import {ClangdContext} from './clangd-context';
 
-export function activate(client: vscodelc.LanguageClient,
-                         context: ClangdContext) {
+export function activate(context: ClangdContext) {
   const status = new FileStatus();
   context.subscriptions.push(vscode.Disposable.from(status));
   context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(
       () => { status.updateStatus(); }));
-  context.subscriptions.push(client.onDidChangeState(({newState}) => {
+  context.subscriptions.push(context.client.onDidChangeState(({newState}) => {
     if (newState == vscodelc.State.Running) {
       // clangd starts or restarts after crash.
-      client.onNotification(
+      context.client.onNotification(
           'textDocument/clangd.fileStatus',
           (fileStatus) => { status.onFileUpdated(fileStatus); });
     } else if (newState == vscodelc.State.Stopped) {

--- a/src/file-status.ts
+++ b/src/file-status.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
+import {ClangdContext} from './clangd-context';
+
 export function activate(client: vscodelc.LanguageClient,
-                         context: vscode.ExtensionContext) {
+                         context: ClangdContext) {
   const status = new FileStatus();
   context.subscriptions.push(vscode.Disposable.from(status));
   context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(

--- a/src/install.ts
+++ b/src/install.ts
@@ -6,12 +6,13 @@ import AbortController from 'abort-controller';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import {ClangdContext} from './clangd-context';
 import * as config from './config';
 
 // Returns the clangd path to be used, or null if clangd is not installed.
-export async function activate(context: vscode.ExtensionContext):
-    Promise<string> {
-  const ui = new UI(context);
+export async function activate(context: ClangdContext,
+                               globalStoragePath: string): Promise<string> {
+  const ui = new UI(context, globalStoragePath);
   context.subscriptions.push(vscode.commands.registerCommand(
       'clangd.install', async () => common.installLatest(ui)));
   context.subscriptions.push(vscode.commands.registerCommand(
@@ -21,9 +22,10 @@ export async function activate(context: vscode.ExtensionContext):
 }
 
 class UI {
-  constructor(private context: vscode.ExtensionContext) {}
+  constructor(private context: ClangdContext,
+              private globalStoragePath: string) {}
 
-  get storagePath(): string { return this.context.globalStoragePath; }
+  get storagePath(): string { return this.globalStoragePath; }
   async choose(prompt: string, options: string[]): Promise<string|undefined> {
     return await vscode.window.showInformationMessage(prompt, ...options);
   }

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -5,8 +5,10 @@ import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 import * as vscodelct from 'vscode-languageserver-types';
 
+import {ClangdContext} from './clangd-context';
+
 export function activate(client: vscodelc.LanguageClient,
-                         context: vscode.ExtensionContext) {
+                         context: ClangdContext) {
   const feature = new SemanticHighlightingFeature(client, context);
   context.subscriptions.push(feature);
   client.registerFeature(feature);
@@ -65,8 +67,7 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
   highlighter: Highlighter;
   // Any disposables that should be cleaned up when clangd crashes.
   private subscriptions: vscode.Disposable[] = [];
-  constructor(client: vscodelc.BaseLanguageClient,
-              context: vscode.ExtensionContext) {
+  constructor(client: vscodelc.BaseLanguageClient, context: ClangdContext) {
     context.subscriptions.push(client.onDidChangeState(({newState}) => {
       if (newState == vscodelc.State.Running) {
         // Register handler for semantic highlighting notification.

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -7,11 +7,10 @@ import * as vscodelct from 'vscode-languageserver-types';
 
 import {ClangdContext} from './clangd-context';
 
-export function activate(client: vscodelc.LanguageClient,
-                         context: ClangdContext) {
-  const feature = new SemanticHighlightingFeature(client, context);
+export function activate(context: ClangdContext) {
+  const feature = new SemanticHighlightingFeature(context);
   context.subscriptions.push(feature);
-  client.registerFeature(feature);
+  context.client.registerFeature(feature);
 }
 
 // Parameters for the semantic highlighting (server-side) push notification.
@@ -67,12 +66,12 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
   highlighter: Highlighter;
   // Any disposables that should be cleaned up when clangd crashes.
   private subscriptions: vscode.Disposable[] = [];
-  constructor(client: vscodelc.BaseLanguageClient, context: ClangdContext) {
-    context.subscriptions.push(client.onDidChangeState(({newState}) => {
+  constructor(context: ClangdContext) {
+    context.subscriptions.push(context.client.onDidChangeState(({newState}) => {
       if (newState == vscodelc.State.Running) {
         // Register handler for semantic highlighting notification.
-        client.onNotification(NotificationType,
-                              this.handleNotification.bind(this));
+        context.client.onNotification(NotificationType,
+                                      this.handleNotification.bind(this));
       } else if (newState == vscodelc.State.Stopped) {
         // Dispose resources when clangd crashes.
         this.dispose();

--- a/src/switch-source-header.ts
+++ b/src/switch-source-header.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
+import {ClangdContext} from './clangd-context';
+
 export function activate(client: vscodelc.LanguageClient,
-                         context: vscode.ExtensionContext) {
+                         context: ClangdContext) {
   context.subscriptions.push(vscode.commands.registerCommand(
       'clangd.switchheadersource', () => switchSourceHeader(client)));
 }

--- a/src/switch-source-header.ts
+++ b/src/switch-source-header.ts
@@ -3,10 +3,9 @@ import * as vscodelc from 'vscode-languageclient/node';
 
 import {ClangdContext} from './clangd-context';
 
-export function activate(client: vscodelc.LanguageClient,
-                         context: ClangdContext) {
+export function activate(context: ClangdContext) {
   context.subscriptions.push(vscode.commands.registerCommand(
-      'clangd.switchheadersource', () => switchSourceHeader(client)));
+      'clangd.switchheadersource', () => switchSourceHeader(context.client)));
 }
 
 namespace SwitchSourceHeaderRequest {

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -8,8 +8,10 @@
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
+import {ClangdContext} from './clangd-context';
+
 export function activate(client: vscodelc.LanguageClient,
-                         context: vscode.ExtensionContext) {
+                         context: ClangdContext) {
   const feature = new TypeHierarchyFeature(client, context);
   client.registerFeature(feature);
 }
@@ -87,8 +89,7 @@ class TypeHierarchyFeature implements vscodelc.StaticFeature {
   private serverSupportsTypeHierarchy = false;
   private state: vscodelc.State;
 
-  constructor(client: vscodelc.LanguageClient,
-              context: vscode.ExtensionContext) {
+  constructor(client: vscodelc.LanguageClient, context: ClangdContext) {
     new TypeHierarchyProvider(context, client);
     context.subscriptions.push(client.onDidChangeState(stateChange => {
       this.state = stateChange.newState;
@@ -131,8 +132,7 @@ class TypeHierarchyProvider implements
   private direction: TypeHierarchyDirection;
   private treeView: vscode.TreeView<TypeHierarchyItem>;
 
-  constructor(context: vscode.ExtensionContext,
-              private client: vscodelc.LanguageClient) {
+  constructor(context: ClangdContext, private client: vscodelc.LanguageClient) {
     context.subscriptions.push(vscode.window.registerTreeDataProvider(
         'clangd.typeHierarchyView', this));
 


### PR DESCRIPTION
When restarting the clangd server, don't just call stop and activate on the same client, but instead tear down the client and instantiate a whole new one. This way we get to see any changed settings (e.g. `clangd.path` or `clangd.arguments`).

I'm new to VS Code development and to Typescript, so please be gentle if I'm doing something stupid here!

Addresses #77.