### PR TITLE
Bump vscode-languageclient and vscode-languageserver-types dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1555,32 +1555,32 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "6.0.0-next.5",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.5.tgz",
-            "integrity": "sha512-IAgsltQPwg/pXOPsdXgbUTCaO9VSKZwirZN5SGtkdYQ/R3VjeC4v00WTVvoNayWMZpoC3O9u0ogqmsKzKhVasQ=="
+            "version": "6.0.0-next.6",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.6.tgz",
+            "integrity": "sha512-w3w1T9tGsInSbGyv2kpi4o6ciMIyfVkM+kAvkxEv4zIv3fs69q3Qyt7ZMLiXnaRFXecIOY2ALDKwIMi0n2IwHQ=="
         },
         "vscode-languageclient": {
-            "version": "7.0.0-next.9",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.9.tgz",
-            "integrity": "sha512-lFO+rN/i72CM2va6iKXq1lD7pJg8J93KEXf0w0boWVqU+DJhWzLrV3pXl8Xk1nCv//qOAyhlc/nx2KZCTeRF/A==",
+            "version": "7.0.0-next.10",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.10.tgz",
+            "integrity": "sha512-J9Hp64j1aaQfXlhMPGI1XAcdsIcSNPAL6022JElzgxsfAydmQfZeKCCNdyybjhmZ+xrep2yoVRAeD5TZFP7y6g==",
             "requires": {
                 "semver": "^6.3.0",
-                "vscode-languageserver-protocol": "3.16.0-next.7"
+                "vscode-languageserver-protocol": "3.16.0-next.8"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0-next.7",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.7.tgz",
-            "integrity": "sha512-tOjrg+K3RddJ547zpC9/LAgTbzadkPuHlqJFFWIcKjVhiJOh73XyY+Ngcu9wukGaTsuSGjJ0W8rlmwanixa0FQ==",
+            "version": "3.16.0-next.8",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.8.tgz",
+            "integrity": "sha512-AWMc7vVN7xuTpQf6A7yvaYjxyKEeMBQWJpkcRgT3EFAYU8PXJK2NCL0wPrgHH2soF/bErxJwajA1vNtCqrsRsg==",
             "requires": {
-                "vscode-jsonrpc": "6.0.0-next.5",
-                "vscode-languageserver-types": "3.16.0-next.3"
+                "vscode-jsonrpc": "6.0.0-next.6",
+                "vscode-languageserver-types": "3.16.0-next.4"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.16.0-next.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.3.tgz",
-            "integrity": "sha512-s/z5ZqSe7VpoXJ6JQcvwRiPPA3nG0nAcJ/HH03zoU6QaFfnkcgPK+HshC3WKPPnC2G08xA0iRB6h7kmyBB5Adg=="
+            "version": "3.16.0-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.4.tgz",
+            "integrity": "sha512-NlKJyGcET/ZBCCLBYIPaGo2c37R03bPYeWXozUtnjyye7+9dhlbMSODyoG2INcQf8zFmB4qhm2UOJjgYEgPCNA=="
         },
         "vscode-test": {
             "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "dependencies": {
         "abort-controller": "^3.0.0",
         "jsonc-parser": "^2.1.0",
-        "vscode-languageclient": "7.0.0-next.9",
-        "vscode-languageserver-types": "3.16.0-next.3",
+        "vscode-languageclient": "7.0.0-next.10",
+        "vscode-languageserver-types": "3.16.0-next.4",
         "@clangd/install": "0.1.3"
     },
     "devDependencies": {


### PR DESCRIPTION
The newer versions are needed to support the call hierarchy protocol.