### PR TITLE
Restrict memory usage button to its own view

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
                 },
                 {
                     "command": "clangd.memoryUsage",
+                    "when": "view == clangd.memoryUsage",
                     "group": "navigation"
                 }
             ],


### PR DESCRIPTION
The "show memory usage" button did not have a when clause, making it
show up in every view title across the editor.