### PR TITLE
Prevent file watcher error when no folder is open

### DIFF
--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -21,15 +21,17 @@ class ConfigFileWatcher {
   createFileSystemWatcher() {
     if (this.databaseWatcher)
       this.databaseWatcher.dispose();
-    this.databaseWatcher = vscode.workspace.createFileSystemWatcher(
-        '{' +
-        vscode.workspace.workspaceFolders.map(f => f.uri.fsPath).join(',') +
-        '}/{build/compile_commands.json,compile_commands.json,compile_flags.txt,.clang-tidy}');
-    this.context.subscriptions.push(this.databaseWatcher.onDidChange(
-        this.handleConfigFilesChanged.bind(this)));
-    this.context.subscriptions.push(this.databaseWatcher.onDidCreate(
-        this.handleConfigFilesChanged.bind(this)));
-    this.context.subscriptions.push(this.databaseWatcher);
+    if (vscode.workspace.workspaceFolders) {
+      this.databaseWatcher = vscode.workspace.createFileSystemWatcher(
+          '{' +
+          vscode.workspace.workspaceFolders.map(f => f.uri.fsPath).join(',') +
+          '}/{build/compile_commands.json,compile_commands.json,compile_flags.txt,.clang-tidy}');
+      this.context.subscriptions.push(this.databaseWatcher.onDidChange(
+          this.handleConfigFilesChanged.bind(this)));
+      this.context.subscriptions.push(this.databaseWatcher.onDidCreate(
+          this.handleConfigFilesChanged.bind(this)));
+      this.context.subscriptions.push(this.databaseWatcher);
+    }
   }
 
   async handleConfigFilesChanged(uri: vscode.Uri) {


### PR DESCRIPTION
This prevents an error that occurs when the extension tries to register the watcher, but no folder is open (for example when only a single c file is).

With this fix, in this case no watcher is registered.