### PR TITLE
Naming cleanups

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,23 +144,23 @@
         "commands": [
             {
                 "command": "clangd.switchheadersource",
-                "title": "Switch between Source/Header"
+                "title": "clangd: Switch between source/header"
             },
             {
                 "command": "clangd.install",
-                "title": "Download clangd language server"
+                "title": "clangd: Download language server"
             },
             {
                 "command": "clangd.update",
-                "title": "Check for clangd language server update"
+                "title": "clangd: Check for language server update"
             },
             {
                 "command": "clangd.activate",
-                "title": "Manually activate clangd extension"
+                "title": "clangd: Manually activate extension"
             },
             {
                 "command": "clangd.restart",
-                "title": "Restart the clangd language server"
+                "title": "clangd: Restart language server"
             },
             {
                 "command": "clangd.typeHierarchy",
@@ -183,7 +183,7 @@
             },
             {
                 "command": "clangd.memoryUsage",
-                "title": "clangd: show memory usage",
+                "title": "clangd: Show memory usage",
                 "enablement": "clangd.memoryUsage.supported",
                 "icon": "$(refresh)"
             },
@@ -210,7 +210,7 @@
             "editor/context": [
                 {
                     "command": "clangd.typeHierarchy",
-                    "when": "resourceLangId == cpp && extension.vscode-clangd.enableTypeHierarchy",
+                    "when": "resourceLangId == cpp && clangd.enableTypeHierarchy",
                     "group": "0_navigation@4",
                     "_comment": "see https://github.com/microsoft/vscode-references-view/blob/f63eaed9934ca5ecc8f3fb3ca096f38c6e5e181f/package.json#L162"
                 }
@@ -262,7 +262,7 @@
                 {
                     "id": "clangd.typeHierarchyView",
                     "name": "Type Hierarchy",
-                    "when": "extension.vscode-clangd.typeHierarchyVisible"
+                    "when": "clangd.typeHierarchyVisible"
                 },
                 {
                     "id": "clangd.memoryUsage",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,7 @@ import {ClangdContext} from './clangd-context';
  *  activated the very first time a command is executed.
  */
 export async function activate(context: vscode.ExtensionContext) {
-  const outputChannel =
-      vscode.window.createOutputChannel('Clangd Language Server');
+  const outputChannel = vscode.window.createOutputChannel('clangd');
   context.subscriptions.push(outputChannel);
 
   const clangdContext = new ClangdContext;

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -126,12 +126,11 @@ class TypeHierarchyFeature implements vscodelc.StaticFeature {
 
   private recomputeEnableTypeHierarchy() {
     if (this.state == vscodelc.State.Running) {
-      vscode.commands.executeCommand(
-          'setContext', 'extension.vscode-clangd.enableTypeHierarchy',
-          this.serverSupportsTypeHierarchy);
+      vscode.commands.executeCommand('setContext', 'clangd.enableTypeHierarchy',
+                                     this.serverSupportsTypeHierarchy);
     } else if (this.state == vscodelc.State.Stopped) {
-      vscode.commands.executeCommand(
-          'setContext', 'extension.vscode-clangd.enableTypeHierarchy', false);
+      vscode.commands.executeCommand('setContext', 'clangd.enableTypeHierarchy',
+                                     false);
     }
   }
 }
@@ -284,8 +283,8 @@ class TypeHierarchyProvider implements
     // This makes the type hierarchy view visible by causing the condition
     // "when": "extension.vscode-clangd.typeHierarchyVisible" from
     // package.json to evaluate to true.
-    vscode.commands.executeCommand(
-        'setContext', 'extension.vscode-clangd.typeHierarchyVisible', true);
+    vscode.commands.executeCommand('setContext', 'clangd.typeHierarchyVisible',
+                                   true);
 
     const item = await this.client.sendRequest(TypeHierarchyRequest.type, {
       ...this.client.code2ProtocolConverter.asTextDocumentPositionParams(
@@ -331,8 +330,8 @@ class TypeHierarchyProvider implements
 
   private close() {
     // Hide the type hierarchy view.
-    vscode.commands.executeCommand(
-        'setContext', 'extension.vscode-clangd.typeHierarchyVisible', false);
+    vscode.commands.executeCommand('setContext', 'clangd.typeHierarchyVisible',
+                                   false);
 
     this.root = undefined;
     this._onDidChangeTreeData.fire(null);


### PR DESCRIPTION
Log in output is named "clangd" (was "Clangd Language Server")

Commands shown in palette are consistently "clangd: foo bar" (some were "foo clangd bar")
Exception: type hierarchy (proposed as standard LSP feature)

Internal resource IDs consistently clangd.foo (some were extension.vscode-clangd.foo)