### PR TITLE
Remove the deprecated set-env command.

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,7 +9,7 @@ jobs:
     - name: start X server
       run: |
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        echo "::set-env name=DISPLAY:::99"
+        echo "DISPLAY=:99" >> $GITHUB_ENV
     - uses: actions/checkout@v2
     - name: detect version
       uses: EndBug/version-check@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: start X server
       run: |
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        echo "::set-env name=DISPLAY:::99"
+        echo "DISPLAY=:99" >> $GITHUB_ENV
     - uses: actions/checkout@v2
     - run: npm ci
     - run: npm build


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/