### PR TITLE
Add "show AST" command, based on textDocument/ast extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,16 @@
                 "command": "clangd.memoryUsage.close",
                 "title": "Close",
                 "icon": "$(panel-close)"
+            },
+            {
+                "command": "clangd.ast",
+                "title": "Show AST",
+                "icon": "$(list-tree)"
+            },
+            {
+                "command": "clangd.ast.close",
+                "title": "Close",
+                "icon": "$(panel-close)"
             }
         ],
         "keybindings": [
@@ -218,6 +228,10 @@
                     "when": "resourceLangId == cpp && clangd.enableTypeHierarchy",
                     "group": "0_navigation@4",
                     "_comment": "see https://github.com/microsoft/vscode-references-view/blob/f63eaed9934ca5ecc8f3fb3ca096f38c6e5e181f/package.json#L162"
+                },
+                {
+                    "command": "clangd.ast",
+                    "when": "clangd.ast.supported"
                 }
             ],
             "view/title": [
@@ -244,6 +258,11 @@
                 {
                     "command": "clangd.memoryUsage",
                     "when": "view == clangd.memoryUsage",
+                    "group": "navigation"
+                },
+                {
+                    "command": "clangd.ast.close",
+                    "when": "view == clangd.ast",
                     "group": "navigation"
                 }
             ],
@@ -273,6 +292,11 @@
                     "id": "clangd.memoryUsage",
                     "name": "clangd Memory Usage",
                     "when": "clangd.memoryUsage.hasData"
+                },
+                {
+                    "id": "clangd.ast",
+                    "name": "AST",
+                    "when": "clangd.ast.hasData"
                 }
             ]
         }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,0 +1,150 @@
+// Implements the "ast dump" feature: textDocument/ast.
+
+import * as vscode from 'vscode';
+import * as vscodelc from 'vscode-languageclient/node';
+
+import {ClangdContext} from './clangd-context';
+
+export function activate(context: ClangdContext) {
+  const feature = new ASTFeature(context);
+  context.client.registerFeature(feature);
+}
+
+// The wire format: we send a position, and get back a tree of ASTNode.
+namespace ASTRequest {
+export const type =
+    new vscodelc.RequestType<ASTParams, ASTNode|null, void, void>(
+        'textDocument/ast');
+}
+
+interface ASTParams {
+  textDocument: vscodelc.TextDocumentIdentifier;
+  range: vscodelc.Range;
+}
+
+interface ASTNode {
+  role: string;    // e.g. expression
+  kind: string;    // e.g. BinaryOperator
+  detail?: string; // e.g. ||
+  arcana?: string; // e.g. BinaryOperator <0x12345> <col:12, col:1> 'bool' '||'
+  children?: Array<ASTNode>;
+  range?: vscodelc.Range;
+}
+
+class ASTFeature implements vscodelc.StaticFeature {
+  constructor(private context: ClangdContext) {
+    // The adapter holds the currently inspected node.
+    const adapter = new TreeAdapter();
+    // Ensure the AST view is visible exactly when the adapter has a node.
+    // clangd.ast.hasData controls the view visibility (package.json).
+    adapter
+        .onDidChangeTreeData(
+            (e) => vscode.commands.executeCommand(
+                'setContext', 'clangd.ast.hasData', adapter.hasRoot()))
+        // Create the AST view, showing data from the adapter.
+        this.context.subscriptions.push(
+            vscode.window.registerTreeDataProvider('clangd.ast', adapter));
+    // Create the "Show AST" command for the context menu.
+    // It's only shown if the feature is dynamicaly available (package.json)
+    vscode.commands.registerTextEditorCommand(
+        'clangd.ast', async (editor, _edit) => {
+          const converter = this.context.client.code2ProtocolConverter;
+          const item = await this.context.client.sendRequest(ASTRequest.type, {
+            textDocument: converter.asTextDocumentIdentifier(editor.document),
+            range: converter.asRange(editor.selection),
+          });
+          if (!item)
+            vscode.window.showInformationMessage('No AST node at selection');
+          adapter.setRoot(item, editor.document.uri);
+        });
+    // Clicking "close" will empty the adapter, which in turn hides the view.
+    vscode.commands.registerCommand('clangd.ast.close',
+                                    () => adapter.setRoot(null, null));
+  }
+
+  fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
+
+  // The "Show AST" command is enabled if the server advertises the capability.
+  initialize(capabilities: vscodelc.ServerCapabilities,
+             _documentSelector: vscodelc.DocumentSelector|undefined) {
+    vscode.commands.executeCommand('setContext', 'clangd.ast.supported',
+                                   'astProvider' in capabilities);
+  }
+}
+
+// Icons used for nodes of particular roles and kinds. (Kind takes precedence).
+// IDs from https://code.visualstudio.com/api/references/icons-in-labels
+const RoleIcons: {[role: string]: string} = {
+  'type': 'symbol-misc',
+  'declaration': 'symbol-function',
+  'expression': 'primitive-dot',
+  'specifier': 'list-tree',
+  'statement': 'symbol-event',
+  'template argument': 'symbol-type-parameter',
+};
+const KindIcons: {[type: string]: string} = {
+  'Compound': 'json',
+  'Recovery': 'error',
+  'TranslationUnit': 'file-code',
+  'PackExpansion': 'ellipsis',
+  'TemplateTypeParm': 'symbol-type-parameter',
+  'TemplateTemplateParm': 'symbol-type-parameter',
+  'TemplateParamObject': 'symbol-type-parameter',
+};
+// Primary text shown for this node.
+function describe(role: string, kind: string): string {
+  // For common roles where the kind is fairly self-explanatory, we don't
+  // include it. e.g. "Call" rather than "Call expression".
+  if (role == 'expression' || role == 'statement' || role == 'declaration' ||
+      role == 'template name')
+    return kind;
+  return kind + ' ' + role;
+}
+
+// Map a root ASTNode onto a VSCode tree.
+class TreeAdapter implements vscode.TreeDataProvider<ASTNode> {
+  private root?: ASTNode;
+  private doc?: vscode.Uri;
+
+  hasRoot(): boolean { return this.root != null; }
+
+  setRoot(newRoot: ASTNode|null, newDoc: vscode.Uri|null) {
+    this.root = newRoot;
+    this.doc = newDoc;
+    this._onDidChangeTreeData.fire(/*root changed*/ null);
+  }
+
+  private _onDidChangeTreeData = new vscode.EventEmitter<ASTNode|null>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  public getTreeItem(node: ASTNode): vscode.TreeItem {
+    const item = new vscode.TreeItem(describe(node.role, node.kind));
+    if (node.children && node.children.length > 0)
+      item.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+    item.description = node.detail;
+    item.tooltip = node.arcana;
+    const icon = KindIcons[node.kind] || RoleIcons[node.role];
+    if (icon)
+      item.iconPath = new vscode.ThemeIcon(icon);
+
+    // Clicking on the node should highlight it in the source.
+    if (node.range && this.doc)
+      item.command = {
+        title: 'Jump to',
+        command: 'vscode.open',
+        arguments: [
+          this.doc, {
+            preserveFocus: true,
+            selection: node.range,
+          } as vscode.TextDocumentShowOptions
+        ],
+      };
+    return item;
+  }
+
+  public async getChildren(element?: ASTNode): Promise<ASTNode[]> {
+    if (!element)
+      return this.root ? [this.root] : [];
+    return element.children || [];
+  }
+}

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
+import * as ast from './ast';
 import * as config from './config';
 import * as configFileWatcher from './config-file-watcher';
 import * as fileStatus from './file-status';
@@ -140,6 +141,7 @@ export class ClangdContext implements vscode.Disposable {
     this.client.registerFeature(new EnableEditsNearCursorFeature);
     typeHierarchy.activate(this);
     memoryUsage.activate(this);
+    ast.activate(this);
     this.subscriptions.push(this.client.start());
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/commit/8adc4d1ec76471bc283d888f3077f7d8f591d6ad
This extension is new, so the feature doesn't work with clangd 11 and earlier.

![2020-11-20-134221_1126x790_scrot](https://user-images.githubusercontent.com/548993/99801424-4b827000-2b36-11eb-92f1-7e054166561f.png)

Implementation is pretty similar to memoryusage (though a bit simpler I think)