### PR TITLE
Add a restartAfterCrash option

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
                     "default": true,
                     "description": "Always rank completion items on the server as you type. This produces more accurate results at the cost of higher latency than client-side filtering."
                 },
+                "clangd.maxRestartCount": {
+                    "type": "number",
+                    "default": 4,
+                    "description": "The maximum count that the extension will restart clangd if clangd crashes."
+                },
                 "clangd.checkUpdates": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -124,10 +124,10 @@
                     "default": true,
                     "description": "Always rank completion items on the server as you type. This produces more accurate results at the cost of higher latency than client-side filtering."
                 },
-                "clangd.maxRestartCount": {
-                    "type": "number",
-                    "default": 4,
-                    "description": "The maximum count that the extension will restart clangd if clangd crashes."
+                "clangd.restartAfterCrash": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Auto restart clangd (up to 4 times) if it crashes."
                 },
                 "clangd.checkUpdates": {
                     "type": "boolean",

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -136,6 +136,9 @@ export class ClangdContext implements vscode.Disposable {
 
     this.client = new ClangdLanguageClient('Clang Language Server',
                                            serverOptions, clientOptions);
+    this.client.clientOptions.errorHandler =
+        this.client.createDefaultErrorHandler(
+            config.get<number>('maxRestartCount'));
     if (config.get<boolean>('semanticHighlighting'))
       semanticHighlighting.activate(this);
     this.client.registerFeature(new EnableEditsNearCursorFeature);

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -139,7 +139,7 @@ export class ClangdContext implements vscode.Disposable {
     this.client.clientOptions.errorHandler =
         this.client.createDefaultErrorHandler(
             // max restart count
-            config.get<boolean>('restartAfterCrash') ? /*default*/4 : 0);
+            config.get<boolean>('restartAfterCrash') ? /*default*/ 4 : 0);
     if (config.get<boolean>('semanticHighlighting'))
       semanticHighlighting.activate(this);
     this.client.registerFeature(new EnableEditsNearCursorFeature);

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -138,7 +138,8 @@ export class ClangdContext implements vscode.Disposable {
                                            serverOptions, clientOptions);
     this.client.clientOptions.errorHandler =
         this.client.createDefaultErrorHandler(
-            config.get<number>('maxRestartCount'));
+            // max restart count
+            config.get<boolean>('restartAfterCrash') ? /*default*/4 : 0);
     if (config.get<boolean>('semanticHighlighting'))
       semanticHighlighting.activate(this);
     this.client.registerFeature(new EnableEditsNearCursorFeature);


### PR DESCRIPTION
Allowing us to control the maximum clangd restart times (by default it is 4), this would make the life of tracking/reporting crashes a bit easier.