### PR TITLE
Add a watcher for clangd.path and clangd.arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,21 @@
                         "Automatically restart the server",
                         "Do nothing"
                     ]
+                },
+                "clangd.onSettingsChanged": {
+                    "type": "string",
+                    "default": "prompt",
+                    "description": "What to do if clangd.path or clangd.arguments is changed.",
+                    "enum": [
+                        "prompt",
+                        "restart",
+                        "ignore"
+                    ],
+                    "enumDescriptions": [
+                        "Prompt the user for restarting the server",
+                        "Automatically restart the server",
+                        "Do nothing"
+                    ]
                 }
             }
         },

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
 import * as config from './config';
-import * as configFileWatcher from './config-file-watcher';
+import * as configWatchers from './config-watchers';
 import * as fileStatus from './file-status';
 import * as install from './install';
 import * as memoryUsage from './memory-usage';
@@ -138,7 +138,7 @@ export class ClangdContext implements vscode.Disposable {
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);
     switchSourceHeader.activate(this);
-    configFileWatcher.activate(this);
+    configWatchers.activate(this);
   }
 
   dispose() {

--- a/src/config-watchers.ts
+++ b/src/config-watchers.ts
@@ -3,10 +3,50 @@ import * as vscode from 'vscode';
 import {ClangdContext} from './clangd-context';
 import * as config from './config';
 
+async function promtRestart(settingName: string, promptMessage: string) {
+  switch (config.get<string>(settingName)) {
+    case 'restart':
+      vscode.commands.executeCommand('clangd.restart');
+      break;
+    case 'ignore':
+      break;
+    case 'prompt':
+    default:
+      switch (await vscode.window.showInformationMessage(
+        promptMessage,
+        'Yes', 'Yes, always', 'No, never')) {
+        case 'Yes':
+          vscode.commands.executeCommand('clangd.restart');
+          break;
+        case 'Yes, always':
+          vscode.commands.executeCommand('clangd.restart');
+          config.update<string>(settingName, 'restart',
+            vscode.ConfigurationTarget.Global);
+          break;
+        case 'No, never':
+          config.update<string>(settingName, 'ignore',
+            vscode.ConfigurationTarget.Global);
+          break;
+        default:
+          break;
+      }
+      break;
+  }
+}
+
 export function activate(context: ClangdContext) {
   if (config.get<string>('onConfigChanged') != 'ignore') {
     const watcher = new ConfigFileWatcher(context);
   }
+  vscode.workspace.onDidChangeConfiguration(event => {
+    let Settings: string[] = ['clangd.path', 'clangd.arguments'];
+    Settings.forEach(element => {
+      if (event.affectsConfiguration(element)) {
+        promtRestart('onSettingsChanged', `setting '${
+                     element}' has changed. Do you want to reload the server?`);
+      }
+    });
+  });
 }
 
 class ConfigFileWatcher {
@@ -39,49 +79,19 @@ class ConfigFileWatcher {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
-
-    this.debounceTimer = setTimeout(async () => {
-      await this.handleConfigFilesChanged(uri);
-      this.debounceTimer = undefined;
-    }, 2000);
-  }
-
-  async handleConfigFilesChanged(uri: vscode.Uri) {
     // Sometimes the tools that generate the compilation database, before
     // writing to it, they create a new empty file or they clear the existing
     // one, and after the compilation they write the new content. In this cases
     // the server is not supposed to restart
-    if ((await vscode.workspace.fs.stat(uri)).size <= 0)
+    if ((await vscode.workspace.fs.stat(uri)).size <= 0) {
+      clearTimeout(this.debounceTimer);
       return;
-
-    switch (config.get<string>('onConfigChanged')) {
-    case 'restart':
-      vscode.commands.executeCommand('clangd.restart');
-      break;
-    case 'ignore':
-      break;
-    case 'prompt':
-    default:
-      switch (await vscode.window.showInformationMessage(
-          `Clangd configuration file at '${
-              uri.fsPath}' has been changed. Do you want to restart it?`,
-          'Yes', 'Yes, always', 'No, never')) {
-      case 'Yes':
-        vscode.commands.executeCommand('clangd.restart');
-        break;
-      case 'Yes, always':
-        vscode.commands.executeCommand('clangd.restart');
-        config.update<string>('onConfigChanged', 'restart',
-                              vscode.ConfigurationTarget.Global);
-        break;
-      case 'No, never':
-        config.update<string>('onConfigChanged', 'ignore',
-                              vscode.ConfigurationTarget.Global);
-        break;
-      default:
-        break;
-      }
-      break;
     }
+    this.debounceTimer = setTimeout(async () => {
+      await promtRestart('onConfigChanged', 
+      `Clangd configuration file at '${
+        uri.fsPath}' has been changed. Do you want to restart it?`);
+      this.debounceTimer = undefined;
+    }, 2000);
   }
 }


### PR DESCRIPTION
When `clangd.path` or `clangd.arguments` is updated, Prompt the user to restart the server.

Addresses #116 