### PR TITLE
Add watcher on settings to restart clangd if needed

### DIFF
--- a/src/config-watcher.ts
+++ b/src/config-watcher.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode';
+
+const WATCHED_SETTINGS: String[] =
+    ['path', 'arguments', 'trace', 'fallbackFlags', 'semanticHighlighting'];
+
+async function handleConfigurationChanged(e: vscode.ConfigurationChangeEvent) {
+  for (let setting of WATCHED_SETTINGS) {
+    if (e.affectsConfiguration(`clangd.${setting}`)) {
+      vscode.commands.executeCommand('clangd.restart');
+      break;
+    }
+  }
+}
+
+export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration(handleConfigurationChanged))
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import {ClangdContext} from './clangd-context';
+import * as ConfigWatcher from './config-watcher';
 
 /**
  *  This method is called when the extension is activated. The extension is
@@ -12,6 +13,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const clangdContext = new ClangdContext;
   context.subscriptions.push(clangdContext);
+
+  // Listen for settings changes
+  ConfigWatcher.activate(context);
 
   // An empty place holder for the activate command, otherwise we'll get an
   // "command is not registered" error.


### PR DESCRIPTION
This PR listens to the workspace event for config change and restarts the clangd server on relevant configuration changes.

Fixes #116 

I did not implement the prompt, because I think that the user expects the configuration to update as soon as it's changed, and the prompt seemed to me a bit redundant