### PR TITLE
Enhanced clangd options UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "6.14.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.9.tgz",
-            "integrity": "sha512-leP/gxHunuazPdZaCvsCefPQxinqUDsCxCR5xaDUrY2MkYxQRFZZwU5e7GojyYsGB7QVtCi7iVEl/hoFXQYc+w==",
+            "version": "8.10.66",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+            "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
             "dev": true
         },
         "@types/vscode": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "devDependencies": {
         "@types/glob": "^7.1.1",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^6.0.40",
+        "@types/node": "^8.10.66",
         "@types/vscode": "1.46.*",
         "clang-format": "1.4.0",
         "glob": "^7.1.4",
@@ -132,7 +132,7 @@
                 "clangd.compileCommandsDir": {
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "Specify a path to look for `compile_commands.json`. If path is invalid, clangd will look in the current directory and parent paths of each source file. If not specified clangd will look in the parent folders of each opened file."
+                    "markdownDescription": "Specify a path to look for `compile_commands.json`. If path is invalid, clangd will look in the current directory and parent paths of each source file. If not specified clangd will look in the parent folders of each opened file. Corresponds to `--compile-commands-dir` flag."
                 },
                 "clangd.queryDrivers": {
                     "type": "array",
@@ -140,25 +140,25 @@
                     "items": {
                         "type": "string"
                     },
-                    "markdownDescription": "Globs for white-listing gcc-compatible drivers that are safe to execute. Drivers matching any of these globs will be used to extract system includes. For example `/usr/bin/**/clang-*` or `/path/to/repo/**/g++-*`"
+                    "markdownDescription": "Globs for white-listing gcc-compatible drivers that are safe to execute. Drivers matching any of these globs will be used to extract system includes. For example `/usr/bin/**/clang-*` or `/path/to/repo/**/g++-*`. Corresponds to `--query-driver` flag. Supported since clangd version 9."
                 },
                 "clangd.backgroundIndex": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Index project code in the background and persist index on disk."
+                    "markdownDescription": "Index project code in the background and persist index on disk. Corresponds to `--background-index` flag.  Supported since clangd version 8."
                 },
                 "clangd.clangTidy": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable clang-tidy diagnostics."
+                    "markdownDescription": "Enable clang-tidy diagnostics. Corresponds to `--clang-tidy` flag. Supported since clangd version 9."
                 },
                 "clangd.crossFileRename": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable cross-file rename feature."
+                    "markdownDescription": "Enable cross-file rename feature. Corresponds to `--cross-file-rename` flag. Supported since clangd version 10."
                 },
                 "clangd.headerInsertion": {
-                    "type":"string",
+                    "type": "string",
                     "enum": [
                         "iwyu",
                         "never"
@@ -168,12 +168,12 @@
                         "Include what you use. Insert the owning header for top-level symbols, unless the header is already directly included or the symbol is forward-declared",
                         "Never insert `#include` directives as part of code completion"
                     ],
-                    "markdownDescription": "Add `#include` directives when accepting code completions."
+                    "markdownDescription": "Add `#include` directives when accepting code completions. Corresponds to `--header-insertion` flag. Supported since clangd version 9."
                 },
                 "clangd.limitResults": {
                     "type": "integer",
                     "default": 100,
-                    "description": "Limit the number of results returned by clangd. 0 means no limit."
+                    "markdownDescription": "Limit the number of results returned by clangd. 0 means no limit. Corresponds to `--limit-results` flag."
                 },
                 "clangd.onConfigChanged": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -86,13 +86,13 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "clangd",
+            "title": "Clangd",
             "properties": {
                 "clangd.path": {
                     "type": "string",
                     "default": "clangd",
                     "scope": "machine-overridable",
-                    "description": "The path to clangd executable, e.g.: /usr/bin/clangd."
+                    "markdownDescription": "The path to clangd executable, e.g.: `/usr/bin/clangd`."
                 },
                 "clangd.arguments": {
                     "type": "array",
@@ -100,7 +100,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "Arguments for clangd server."
+                    "description": "Arguments for clangd server. For backwards compatibility it has precedence over other UI specified options."
                 },
                 "clangd.trace": {
                     "type": "string",
@@ -128,6 +128,52 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Check for language server updates on startup."
+                },
+                "clangd.compileCommandsDir": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Specify a path to look for `compile_commands.json`. If path is invalid, clangd will look in the current directory and parent paths of each source file. If not specified clangd will look in the parent folders of each opened file."
+                },
+                "clangd.queryDrivers": {
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "markdownDescription": "Globs for white-listing gcc-compatible drivers that are safe to execute. Drivers matching any of these globs will be used to extract system includes. For example `/usr/bin/**/clang-*` or `/path/to/repo/**/g++-*`"
+                },
+                "clangd.backgroundIndex": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Index project code in the background and persist index on disk."
+                },
+                "clangd.clangTidy": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable clang-tidy diagnostics."
+                },
+                "clangd.crossFileRename": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable cross-file rename feature."
+                },
+                "clangd.headerInsertion": {
+                    "type":"string",
+                    "enum": [
+                        "iwyu",
+                        "never"
+                    ],
+                    "default": "iwyu",
+                    "markdownEnumDescriptions": [
+                        "Include what you use. Insert the owning header for top-level symbols, unless the header is already directly included or the symbol is forward-declared",
+                        "Never insert `#include` directives as part of code completion"
+                    ],
+                    "markdownDescription": "Add `#include` directives when accepting code completions."
+                },
+                "clangd.limitResults": {
+                    "type": "integer",
+                    "default": 100,
+                    "description": "Limit the number of results returned by clangd. 0 means no limit."
                 },
                 "clangd.onConfigChanged": {
                     "type": "string",

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -1,0 +1,69 @@
+import * as config from './config';
+
+function argsContainFlag(args: string[], flag: string) {
+  for (let arg of args) {
+    if (arg.startsWith(flag))
+      return true;
+  }
+
+  return false;
+}
+
+export function getClangdArguments() {
+  let args = config.get<string[]>('arguments');
+
+  let compileCommandsDirFlag = '--compile-commands-dir';
+
+  if (!argsContainFlag(args, compileCommandsDirFlag)) {
+    let compileCommandsDir = config.get<string>('compileCommandsDir');
+    if (compileCommandsDir.length > 0)
+      args.push(`${compileCommandsDirFlag}=${compileCommandsDir}`);
+  }
+
+  let queryDriversFlag = '--query-driver';
+
+  if (!argsContainFlag(args, queryDriversFlag)) {
+    let queryDrivers = config.get<string[]>('queryDrivers');
+    if (queryDrivers.length > 0) {
+      let drivers = queryDrivers.join(',');
+      args.push(`${queryDriversFlag}=${drivers}`);
+    }
+  }
+
+  let backgroundIndexFlag = '--background-index';
+
+  if (!argsContainFlag(args, backgroundIndexFlag)) {
+    let backgroundIndex = config.get<boolean>('backgroundIndex');
+    args.push(`${backgroundIndexFlag}=${backgroundIndex}`);
+  }
+
+  let clangTidyFlag = '--clang-tidy';
+
+  if (!argsContainFlag(args, clangTidyFlag)) {
+    let clangTidy = config.get<boolean>('clangTidy');
+    args.push(`${clangTidyFlag}=${clangTidy}`)
+  }
+
+  let crossFileRenameFlag = '--cross-file-rename';
+
+  if (!argsContainFlag(args, crossFileRenameFlag)) {
+    let crossFileRename = config.get<boolean>('crossFileRename');
+    args.push(`${crossFileRenameFlag}=${crossFileRename}`);
+  }
+
+  let headerInsertionFlag = '--header-insertion';
+
+  if (!argsContainFlag(args, headerInsertionFlag)) {
+    let headerInsertion = config.get<string>('headerInsertion');
+    args.push(`${headerInsertionFlag}=${headerInsertion}`);
+  }
+
+  let limitResultsFlag = '--limit-results';
+
+  if (!argsContainFlag(args, limitResultsFlag)) {
+    let limitResults = config.get<number>('limitResults');
+    args.push(`${limitResultsFlag}=${limitResults}`);
+  }
+
+  return args;
+}

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -51,7 +51,7 @@ export class ClangdContext implements vscode.Disposable {
 
     const clangd: vscodelc.Executable = {
       command: clangdPath,
-      args: args.getClangdArguments()
+      args: await args.getClangdArguments(clangdPath)
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
+import * as args from './arguments';
 import * as config from './config';
 import * as configFileWatcher from './config-file-watcher';
 import * as fileStatus from './file-status';
@@ -50,7 +51,7 @@ export class ClangdContext implements vscode.Disposable {
 
     const clangd: vscodelc.Executable = {
       command: clangdPath,
-      args: config.get<string[]>('arguments')
+      args: args.getClangdArguments()
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {


### PR DESCRIPTION
In this PR I exposed a few clangd options in the vscode UI for an easier configuration by the user.

For backwards compatibility, the preexisting `clangd.arguments` setting has precedence over all the new options. This way, existing projects/configurations that are already working won't change behaviour without the user knowing it.

I chose a few (for me) common options to avoid adding too much clutter (of course I can add more if you think they're important):

* `--compile-commands-dir` by default empty
* `--query-driver` by default empty
* `--background-index` by default true
* `--clang-tidy` by default false
* `--cross-file-rename` by default false
* `--header-insertion` by default iwyu
* `--limit-results` by default 100

Default vaues have been chosen according to clangd default values.

All options are used only if the current clangd binary supports them, by checking its major version. Versions before 7 are not checked for compatibility.

Note that I could not test it on windows/mac machines and with older clangd versions.

Fixes: #50 