### PR TITLE
Bump vscode-languageclient and vscode-languageserver-types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
-            "integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
             "dev": true
         },
         "abort-controller": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -896,6 +896,14 @@
                 "chalk": "^2.4.2"
             }
         },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
         "markdown-it": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
@@ -1312,9 +1320,12 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -1555,32 +1566,33 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "6.0.0-next.6",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.6.tgz",
-            "integrity": "sha512-w3w1T9tGsInSbGyv2kpi4o6ciMIyfVkM+kAvkxEv4zIv3fs69q3Qyt7ZMLiXnaRFXecIOY2ALDKwIMi0n2IwHQ=="
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
         },
         "vscode-languageclient": {
-            "version": "7.0.0-next.10",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.10.tgz",
-            "integrity": "sha512-J9Hp64j1aaQfXlhMPGI1XAcdsIcSNPAL6022JElzgxsfAydmQfZeKCCNdyybjhmZ+xrep2yoVRAeD5TZFP7y6g==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
             "requires": {
-                "semver": "^6.3.0",
-                "vscode-languageserver-protocol": "3.16.0-next.8"
+                "minimatch": "^3.0.4",
+                "semver": "^7.3.4",
+                "vscode-languageserver-protocol": "3.16.0"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0-next.8",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.8.tgz",
-            "integrity": "sha512-AWMc7vVN7xuTpQf6A7yvaYjxyKEeMBQWJpkcRgT3EFAYU8PXJK2NCL0wPrgHH2soF/bErxJwajA1vNtCqrsRsg==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
             "requires": {
-                "vscode-jsonrpc": "6.0.0-next.6",
-                "vscode-languageserver-types": "3.16.0-next.4"
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.16.0-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.4.tgz",
-            "integrity": "sha512-NlKJyGcET/ZBCCLBYIPaGo2c37R03bPYeWXozUtnjyye7+9dhlbMSODyoG2INcQf8zFmB4qhm2UOJjgYEgPCNA=="
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "vscode-test": {
             "version": "1.3.0",
@@ -1666,6 +1678,11 @@
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
             "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
             "dev": true
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yargs": {
             "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "homepage": "https://clangd.llvm.org/",
     "icon": "icon.png",
     "engines": {
-        "vscode": "^1.46.0"
+        "vscode": "^1.52.0"
     },
     "categories": [
         "Programming Languages",
@@ -53,7 +53,7 @@
         "@types/glob": "^7.1.1",
         "@types/mocha": "^7.0.2",
         "@types/node": "^6.0.40",
-        "@types/vscode": "1.46.*",
+        "@types/vscode": "1.52.*",
         "clang-format": "1.4.0",
         "glob": "^7.1.4",
         "mocha": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "dependencies": {
         "abort-controller": "^3.0.0",
         "jsonc-parser": "^2.1.0",
-        "vscode-languageclient": "7.0.0-next.10",
-        "vscode-languageserver-types": "3.16.0-next.4",
+        "vscode-languageclient": "7.0.0",
+        "vscode-languageserver-types": "3.16.0",
         "@clangd/install": "0.1.3"
     },
     "devDependencies": {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -36,6 +36,7 @@ class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
         capabilities.textDocument.completion;
     extendedCompletionCapabilities.editsNearCursor = true;
   }
+  dispose() {}
 }
 
 export class ClangdContext implements vscode.Disposable {

--- a/src/memory-usage.ts
+++ b/src/memory-usage.ts
@@ -65,16 +65,16 @@ class MemoryUsageFeature implements vscodelc.StaticFeature {
     this.context.subscriptions.push(vscode.commands.registerCommand(
         'clangd.memoryUsage.close', () => adapter.root = null));
   }
-  fillInitializeParams?: (params: vscodelc.InitializeParams) => void;
-  dispose() {}
 
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
+  fillInitializeParams(_params: vscodelc.InitializeParams) {}
 
   initialize(capabilities: vscodelc.ServerCapabilities,
              _documentSelector: vscodelc.DocumentSelector|undefined) {
     vscode.commands.executeCommand('setContext', 'clangd.memoryUsage.supported',
                                    'memoryUsageProvider' in capabilities);
   }
+  dispose() {}
 }
 
 class TreeAdapter implements vscode.TreeDataProvider<InternalTree> {

--- a/src/memory-usage.ts
+++ b/src/memory-usage.ts
@@ -23,7 +23,7 @@ interface WireTree {
   [child: string]: WireTree|number;
 }
 export const MemoryUsageRequest =
-    new vscodelc.RequestType<NoParams, WireTree, void, void>('$/memoryUsage');
+    new vscodelc.RequestType<NoParams, WireTree, void>('$/memoryUsage');
 
 // Internal representation that's a bit easier to work with.
 interface InternalTree {
@@ -65,6 +65,8 @@ class MemoryUsageFeature implements vscodelc.StaticFeature {
     this.context.subscriptions.push(vscode.commands.registerCommand(
         'clangd.memoryUsage.close', () => adapter.root = null));
   }
+  fillInitializeParams?: (params: vscodelc.InitializeParams) => void;
+  dispose() {}
 
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
 

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -53,7 +53,7 @@ export interface SemanticHighlightingLine {
 // Language server push notification providing the semantic highlighting
 // information for a text document.
 const NotificationType =
-    new vscodelc.NotificationType<SemanticHighlightingParams, void>(
+    new vscodelc.NotificationType<SemanticHighlightingParams>(
         'textDocument/semanticHighlighting');
 
 // The feature that should be registered in the vscode lsp for enabling

--- a/src/switch-source-header.ts
+++ b/src/switch-source-header.ts
@@ -10,8 +10,9 @@ export function activate(context: ClangdContext) {
 
 namespace SwitchSourceHeaderRequest {
 export const type =
-    new vscodelc.RequestType<vscodelc.TextDocumentIdentifier, string|undefined,
-                             void>('textDocument/switchSourceHeader');
+    new vscodelc
+        .RequestType<vscodelc.TextDocumentIdentifier, string|undefined, void>(
+            'textDocument/switchSourceHeader');
 }
 
 async function switchSourceHeader(client: vscodelc.LanguageClient):

--- a/src/switch-source-header.ts
+++ b/src/switch-source-header.ts
@@ -11,7 +11,7 @@ export function activate(context: ClangdContext) {
 namespace SwitchSourceHeaderRequest {
 export const type =
     new vscodelc.RequestType<vscodelc.TextDocumentIdentifier, string|undefined,
-                             void, void>('textDocument/switchSourceHeader');
+                             void>('textDocument/switchSourceHeader');
 }
 
 async function switchSourceHeader(client: vscodelc.LanguageClient):

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -43,9 +43,8 @@ interface TypeHierarchyItem {
 
 namespace TypeHierarchyRequest {
 export const type =
-    new vscodelc
-        .RequestType<TypeHierarchyParams, TypeHierarchyItem|null, void>(
-            'textDocument/typeHierarchy');
+    new vscodelc.RequestType<TypeHierarchyParams, TypeHierarchyItem|null, void>(
+        'textDocument/typeHierarchy');
 }
 
 interface ResolveTypeHierarchyItemParams {
@@ -55,10 +54,9 @@ interface ResolveTypeHierarchyItemParams {
 }
 
 export namespace ResolveTypeHierarchyRequest {
-export const type =
-    new vscodelc.RequestType<ResolveTypeHierarchyItemParams,
-                             TypeHierarchyItem|null, void>(
-        'typeHierarchy/resolve');
+export const type = new vscodelc.RequestType<ResolveTypeHierarchyItemParams,
+                                             TypeHierarchyItem|null, void>(
+    'typeHierarchy/resolve');
 }
 
 // A dummy node used to indicate that a node has multiple parents

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -44,7 +44,7 @@ interface TypeHierarchyItem {
 namespace TypeHierarchyRequest {
 export const type =
     new vscodelc
-        .RequestType<TypeHierarchyParams, TypeHierarchyItem|null, void, void>(
+        .RequestType<TypeHierarchyParams, TypeHierarchyItem|null, void>(
             'textDocument/typeHierarchy');
 }
 
@@ -57,7 +57,7 @@ interface ResolveTypeHierarchyItemParams {
 export namespace ResolveTypeHierarchyRequest {
 export const type =
     new vscodelc.RequestType<ResolveTypeHierarchyItemParams,
-                             TypeHierarchyItem|null, void, void>(
+                             TypeHierarchyItem|null, void>(
         'typeHierarchy/resolve');
 }
 
@@ -111,6 +111,8 @@ class TypeHierarchyFeature implements vscodelc.StaticFeature {
       this.recomputeEnableTypeHierarchy();
     }));
   }
+  fillInitializeParams?: (params: vscodelc.InitializeParams) => void;
+  dispose() {}
 
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
 

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -109,10 +109,9 @@ class TypeHierarchyFeature implements vscodelc.StaticFeature {
       this.recomputeEnableTypeHierarchy();
     }));
   }
-  fillInitializeParams?: (params: vscodelc.InitializeParams) => void;
-  dispose() {}
 
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
+  fillInitializeParams(_params: vscodelc.InitializeParams) {}
 
   initialize(capabilities: vscodelc.ServerCapabilities,
              documentSelector: vscodelc.DocumentSelector|undefined) {
@@ -123,6 +122,7 @@ class TypeHierarchyFeature implements vscodelc.StaticFeature {
       this.recomputeEnableTypeHierarchy();
     }
   }
+  dispose() {}
 
   private recomputeEnableTypeHierarchy() {
     if (this.state == vscodelc.State.Running) {


### PR DESCRIPTION
LSP 3.16.0 is officially released, and bump all dependencies.

Fix #58.