### PR TITLE
Disable config file watcher if a hot-reload capability is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
                 "clangd.onConfigChanged": {
                     "type": "string",
                     "default": "prompt",
-                    "description": "What to do when clangd configuration files are changed.",
+                    "description": "What to do when clangd configuration files are changed. Ignored for clangd 12+, which can reload such files itself.",
                     "enum": [
                         "prompt",
                         "restart",

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -26,6 +26,7 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
       return;
     this.context.subscriptions.push(new ConfigFileWatcher(this.context));
   }
+  dispose() {}
 }
 
 class ConfigFileWatcher implements vscode.Disposable {

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -12,9 +12,7 @@ export function activate(context: ClangdContext) {
 
 // Clangd extension capabilities.
 interface ClangdClientCapabilities {
-  compilationDatabase?: {
-    automaticReload?: boolean;
-  },
+  compilationDatabase?: {automaticReload?: boolean;},
 }
 
 class ConfigFileWatcherFeature implements vscodelc.StaticFeature {


### PR DESCRIPTION
Corresponds to https://reviews.llvm.org/D94222

This is the minimal change. I have a feeling the dispose/re-watch logic could be made cleaner.
But this client-side feature can just be removed in future, so I'm not sure it's worth the risk of trying to polish it.

I've tested this locally with clangd with/without the capability.