### PR TITLE
Warn about conflict with ms-vscode.cpptools

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,13 +13,6 @@ export async function activate(context: vscode.ExtensionContext) {
   const clangdContext = new ClangdContext;
   context.subscriptions.push(clangdContext);
 
-  if (vscode.extensions.getExtension('ms-vscode.cpptools') !== undefined) {
-    vscode.window.showWarningMessage(
-        'You have Microsoft C++ (ms-vscode.cpptools) extension enabled, it is ' +
-            'known to conflict with vscode-clangd. We recommend disabling it.',
-        'Got it');
-  }
-
   // An empty place holder for the activate command, otherwise we'll get an
   // "command is not registered" error.
   context.subscriptions.push(
@@ -31,4 +24,28 @@ export async function activate(context: vscode.ExtensionContext) {
       }));
 
   await clangdContext.activate(context.globalStoragePath, outputChannel);
+
+  setInterval(function() {
+    const cpptools = vscode.extensions.getExtension('ms-vscode.cpptools');
+    if (cpptools !== undefined && cpptools.isActive) {
+      const intellisenseEnabled =
+          vscode.workspace.getConfiguration('C_Cpp').get('intelliSenseEngine');
+      const DisableIt = 'Disable cpptools';
+      if (intellisenseEnabled === 'Default' || intellisenseEnabled === true) {
+        vscode.window
+            .showWarningMessage(
+                'You have Microsoft C++ (ms-vscode.cpptools) extension enabled, it is ' +
+                    'known to conflict with vscode-clangd. We recommend disabling it.',
+                DisableIt, 'Got it')
+            .then(selection => {
+              console.log('selection');
+              if (selection === DisableIt) {
+                vscode.workspace.getConfiguration('C_Cpp').update(
+                    'intelliSenseEngine', false,
+                    vscode.ConfigurationTarget.Global);
+              }
+            });
+      }
+    }
+  }, 5000);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,8 +28,7 @@ export async function activate(context: vscode.ExtensionContext) {
   setInterval(function() {
     const cpptools = vscode.extensions.getExtension('ms-vscode.cpptools');
     if (cpptools !== undefined && cpptools.isActive) {
-      const cpptoolsConfiguration =
-        vscode.workspace.getConfiguration('C_Cpp');
+      const cpptoolsConfiguration = vscode.workspace.getConfiguration('C_Cpp');
       const cpptoolsEnabled = cpptoolsConfiguration.get('intelliSenseEngine');
       if (cpptoolsEnabled !== 'Disabled') {
         const DisableIt = 'Disable cpptools';
@@ -40,9 +39,8 @@ export async function activate(context: vscode.ExtensionContext) {
                 DisableIt, 'Got it')
             .then(selection => {
               if (selection === DisableIt) {
-                cpptoolsConfiguration.update(
-                    'intelliSenseEngine', 'Disabled',
-                    vscode.ConfigurationTarget.Global);
+                cpptoolsConfiguration.update('intelliSenseEngine', 'Disabled',
+                                             vscode.ConfigurationTarget.Global);
               }
             });
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,6 @@ export async function activate(context: vscode.ExtensionContext) {
                     'known to conflict with vscode-clangd. We recommend disabling it.',
                 DisableIt, 'Got it')
             .then(selection => {
-              console.log('selection');
               if (selection === DisableIt) {
                 vscode.workspace.getConfiguration('C_Cpp').update(
                     'intelliSenseEngine', false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,10 +28,11 @@ export async function activate(context: vscode.ExtensionContext) {
   setInterval(function() {
     const cpptools = vscode.extensions.getExtension('ms-vscode.cpptools');
     if (cpptools !== undefined && cpptools.isActive) {
-      const intellisenseEnabled =
-          vscode.workspace.getConfiguration('C_Cpp').get('intelliSenseEngine');
-      const DisableIt = 'Disable cpptools';
-      if (intellisenseEnabled === 'Default' || intellisenseEnabled === true) {
+      const cpptoolsConfiguration =
+        vscode.workspace.getConfiguration('C_Cpp');
+      const cpptoolsEnabled = cpptoolsConfiguration.get('intelliSenseEngine');
+      if (cpptoolsEnabled !== 'Disabled') {
+        const DisableIt = 'Disable cpptools';
         vscode.window
             .showWarningMessage(
                 'You have Microsoft C++ (ms-vscode.cpptools) extension enabled, it is ' +
@@ -39,8 +40,8 @@ export async function activate(context: vscode.ExtensionContext) {
                 DisableIt, 'Got it')
             .then(selection => {
               if (selection === DisableIt) {
-                vscode.workspace.getConfiguration('C_Cpp').update(
-                    'intelliSenseEngine', false,
+                cpptoolsConfiguration.update(
+                    'intelliSenseEngine', 'Disabled',
                     vscode.ConfigurationTarget.Global);
               }
             });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,18 +31,15 @@ export async function activate(context: vscode.ExtensionContext) {
       const cpptoolsConfiguration = vscode.workspace.getConfiguration('C_Cpp');
       const cpptoolsEnabled = cpptoolsConfiguration.get('intelliSenseEngine');
       if (cpptoolsEnabled !== 'Disabled') {
-        const DisableIt = 'Disable cpptools';
         vscode.window
             .showWarningMessage(
                 'You have Microsoft C++ (ms-vscode.cpptools) extension ' +
                     'enabled, it is known to conflict with vscode-clangd. We ' +
                     'recommend disabling it.',
-                DisableIt, 'Got it')
-            .then(selection => {
-              if (selection === DisableIt) {
-                cpptoolsConfiguration.update('intelliSenseEngine', 'Disabled',
-                                             vscode.ConfigurationTarget.Global);
-              }
+                'Disable cpptools')
+            .then(_ => {
+              cpptoolsConfiguration.update('intelliSenseEngine', 'Disabled',
+                                           vscode.ConfigurationTarget.Global);
             });
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,9 +15,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   if (vscode.extensions.getExtension('ms-vscode.cpptools') !== undefined) {
     vscode.window.showWarningMessage(
-      "You have Microsoft C++ (ms-vscode.cpptools) extensions enabled, it is " +
-      "known to conflict with vscode-clangd. We recommend disabling it.",
-      "Got it");
+        'You have Microsoft C++ (ms-vscode.cpptools) extensions enabled, it is ' +
+            'known to conflict with vscode-clangd. We recommend disabling it.',
+        'Got it');
   }
 
   // An empty place holder for the activate command, otherwise we'll get an

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   if (vscode.extensions.getExtension('ms-vscode.cpptools') !== undefined) {
     vscode.window.showWarningMessage(
-        'You have Microsoft C++ (ms-vscode.cpptools) extensions enabled, it is ' +
+        'You have Microsoft C++ (ms-vscode.cpptools) extension enabled, it is ' +
             'known to conflict with vscode-clangd. We recommend disabling it.',
         'Got it');
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,13 @@ export async function activate(context: vscode.ExtensionContext) {
   const clangdContext = new ClangdContext;
   context.subscriptions.push(clangdContext);
 
+  if (vscode.extensions.getExtension('ms-vscode.cpptools') !== undefined) {
+    vscode.window.showWarningMessage(
+      "You have Microsoft C++ (ms-vscode.cpptools) extensions enabled, it is " +
+      "known to conflict with vscode-clangd. We recommend disabling it.",
+      "Got it");
+  }
+
   // An empty place holder for the activate command, otherwise we'll get an
   // "command is not registered" error.
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,8 +34,9 @@ export async function activate(context: vscode.ExtensionContext) {
         const DisableIt = 'Disable cpptools';
         vscode.window
             .showWarningMessage(
-                'You have Microsoft C++ (ms-vscode.cpptools) extension enabled, it is ' +
-                    'known to conflict with vscode-clangd. We recommend disabling it.',
+                'You have Microsoft C++ (ms-vscode.cpptools) extension ' +
+                    'enabled, it is known to conflict with vscode-clangd. We ' +
+                    'recommend disabling it.',
                 DisableIt, 'Got it')
             .then(selection => {
               if (selection === DisableIt) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,19 +26,19 @@ export async function activate(context: vscode.ExtensionContext) {
   await clangdContext.activate(context.globalStoragePath, outputChannel);
 
   setInterval(function() {
-    const cpptools = vscode.extensions.getExtension('ms-vscode.cpptools');
-    if (cpptools !== undefined && cpptools.isActive) {
-      const cpptoolsConfiguration = vscode.workspace.getConfiguration('C_Cpp');
-      const cpptoolsEnabled = cpptoolsConfiguration.get('intelliSenseEngine');
-      if (cpptoolsEnabled !== 'Disabled') {
+    const cppTools = vscode.extensions.getExtension('ms-vscode.cpptools');
+    if (cppTools && cppTools.isActive) {
+      const cppToolsConfiguration = vscode.workspace.getConfiguration('C_Cpp');
+      const cppToolsEnabled = cppToolsConfiguration.get('intelliSenseEngine');
+      if (cppToolsEnabled !== 'Disabled') {
         vscode.window
             .showWarningMessage(
-                'You have Microsoft C++ (ms-vscode.cpptools) extension ' +
-                    'enabled, it is known to conflict with vscode-clangd. We ' +
-                    'recommend disabling it.',
-                'Disable cpptools')
+                'You have both the Microsoft C++ (cpptools) extension and ' +
+                    'clangd extension enabled. The Microsoft IntelliSense features ' +
+                    'conflict with clangd\'s code completion, diagnostics etc.',
+                'Disable IntelliSense')
             .then(_ => {
-              cpptoolsConfiguration.update('intelliSenseEngine', 'Disabled',
+              cppToolsConfiguration.update('intelliSenseEngine', 'Disabled',
                                            vscode.ConfigurationTarget.Global);
             });
       }


### PR DESCRIPTION
`vscode-clangd` is known to create confusing user experience when `ms-vscode.cpptools` extension is enabled but it is not clear to the users. This patch creates a warning for described scenario.