### PR TITLE
Ensure clangd is executed in vscode.workspace.rootPath

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -50,9 +50,15 @@ export class ClangdContext implements vscode.Disposable {
     if (!clangdPath)
       return;
 
+    const rootPath: string = vscode.workspace.rootPath
+    const targetCwd: string = (rootPath !== undefined) ? rootPath : process.cwd();
+    const clangdExecOptions: vscodelc.ExecutableOptions = {
+      cwd: targetCwd
+    }
     const clangd: vscodelc.Executable = {
       command: clangdPath,
-      args: config.get<string[]>('arguments')
+      args: config.get<string[]>('arguments'),
+      options: clangdExecOptions
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -50,11 +50,12 @@ export class ClangdContext implements vscode.Disposable {
     if (!clangdPath)
       return;
 
-    const rootPath: string = vscode.workspace.rootPath
-    const targetCwd: string = (rootPath !== undefined) ? rootPath : process.cwd();
+    const rootPath: string = vscode.workspace.rootPath;
+    const targetCwd: string =
+        (rootPath !== undefined) ? rootPath : process.cwd();
     const clangdExecOptions: vscodelc.ExecutableOptions = {
       cwd: targetCwd
-    }
+    };
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: config.get<string[]>('arguments'),

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -50,14 +50,10 @@ export class ClangdContext implements vscode.Disposable {
     if (!clangdPath)
       return;
 
-    const rootPath: string = vscode.workspace.rootPath;
-    const targetCwd: string =
-        (rootPath !== undefined) ? rootPath : process.cwd();
-    const clangdExecOptions: vscodelc.ExecutableOptions = {cwd: targetCwd};
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: config.get<string[]>('arguments'),
-      options: clangdExecOptions
+      options: {cwd: vscode.workspace.rootPath || process.cwd() }
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -53,7 +53,7 @@ export class ClangdContext implements vscode.Disposable {
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: config.get<string[]>('arguments'),
-      options: {cwd: vscode.workspace.rootPath || process.cwd() }
+      options: {cwd: vscode.workspace.rootPath || process.cwd()}
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -53,9 +53,7 @@ export class ClangdContext implements vscode.Disposable {
     const rootPath: string = vscode.workspace.rootPath;
     const targetCwd: string =
         (rootPath !== undefined) ? rootPath : process.cwd();
-    const clangdExecOptions: vscodelc.ExecutableOptions = {
-      cwd: targetCwd
-    };
+    const clangdExecOptions: vscodelc.ExecutableOptions = {cwd: targetCwd};
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: config.get<string[]>('arguments'),


### PR DESCRIPTION
If the rootPath of a project is a symlink vscode can execute clangd in
the users home-directory. This can cause problems if one is, for
example, using a wrapper script which relies on knowing the current
project. This solves this issue by forcing the clangd to execute in
`vscode.workspace.rootPath` if available.

Test: manual