### PR TITLE
Enable "strict" compiler option

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -24,7 +24,8 @@ interface ASTNode {
   range?: vscodelc.Range;
 }
 const ASTRequestType =
-    new vscodelc.RequestType<ASTParams, ASTNode|null, void>('textDocument/ast');
+    new vscodelc.RequestType<ASTParams, ASTNode|undefined, void>(
+        'textDocument/ast');
 
 class ASTFeature implements vscodelc.StaticFeature {
   constructor(private context: ClangdContext) {
@@ -39,11 +40,11 @@ class ASTFeature implements vscodelc.StaticFeature {
         // clangd.ast.hasData controls the view visibility (package.json).
         adapter.onDidChangeTreeData((_) => {
           vscode.commands.executeCommand('setContext', 'clangd.ast.hasData',
-                                         adapter.hasRoot())
-          // Show the AST tree even if it's beet collapsed or closed.
+                                         adapter.hasRoot());
+          // Show the AST tree even if it's been collapsed or closed.
           // reveal(root) fails here: "Data tree node not found".
           if (adapter.hasRoot())
-          tree.reveal(null);
+            tree.reveal(null!);
         }),
         vscode.window.registerTreeDataProvider('clangd.ast', adapter),
         // Create the "Show AST" command for the context menu.
@@ -65,8 +66,8 @@ class ASTFeature implements vscodelc.StaticFeature {
             }),
         // Clicking "close" will empty the adapter, which in turn hides the
         // view.
-        vscode.commands.registerCommand('clangd.ast.close',
-                                        () => adapter.setRoot(null, null)));
+        vscode.commands.registerCommand(
+            'clangd.ast.close', () => adapter.setRoot(undefined, undefined)));
   }
 
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
@@ -122,7 +123,7 @@ class TreeAdapter implements vscode.TreeDataProvider<ASTNode> {
 
   hasRoot(): boolean { return this.root != null; }
 
-  setRoot(newRoot: ASTNode|null, newDoc: vscode.Uri|null) {
+  setRoot(newRoot: ASTNode|undefined, newDoc: vscode.Uri|undefined) {
     this.root = newRoot;
     this.doc = newDoc;
     this._onDidChangeTreeData.fire(/*root changed*/ null);
@@ -163,16 +164,16 @@ class TreeAdapter implements vscode.TreeDataProvider<ASTNode> {
     return element.children || [];
   }
 
-  public getParent(node: ASTNode): ASTNode {
+  public getParent(node: ASTNode): ASTNode|undefined {
     if (node == this.root)
-      return null;
-    function findUnder(parent: ASTNode): ASTNode|null {
-      for (const child of parent.children || []) {
+      return undefined;
+    function findUnder(parent: ASTNode|undefined): ASTNode|undefined {
+      for (const child of parent?.children || []) {
         const result = (node == child) ? parent : findUnder(child);
         if (result)
           return result;
       }
-      return null;
+      return undefined;
     }
     return findUnder(this.root);
   }

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -58,7 +58,7 @@ export class ClangdContext implements vscode.Disposable {
           await config.getSecureOrPrompt<string[]>('arguments', workspaceState),
       options: {cwd: vscode.workspace.rootPath || process.cwd()}
     };
-    const traceFile = config.get<string>('trace', '');
+    const traceFile = config.get<string>('trace');
     if (!!traceFile) {
       const trace = {CLANGD_TRACE: traceFile};
       clangd.options = {env: {...process.env, ...trace}};
@@ -77,7 +77,7 @@ export class ClangdContext implements vscode.Disposable {
       ],
       initializationOptions: {
         clangdFileStatus: true,
-        fallbackFlags: config.get<string[]>('fallbackFlags', [])
+        fallbackFlags: config.get<string[]>('fallbackFlags')
       },
       outputChannel: outputChannel,
       // Do not switch to output window when clangd returns output.
@@ -101,7 +101,7 @@ export class ClangdContext implements vscode.Disposable {
         provideCompletionItem: async (document, position, context, token,
                                       next) => {
           let list = await next(document, position, context, token);
-          if (!config.get<boolean>('serverCompletionRanking', true))
+          if (!config.get<boolean>('serverCompletionRanking'))
             return list;
           let items = (Array.isArray(list) ? list : list!.items).map(item => {
             // Gets the prefix used by VSCode when doing fuzzymatch.
@@ -143,8 +143,8 @@ export class ClangdContext implements vscode.Disposable {
     this.client.clientOptions.errorHandler =
         this.client.createDefaultErrorHandler(
             // max restart count
-            config.get<boolean>('restartAfterCrash', true) ? /*default*/ 4 : 0);
-    if (config.get<boolean>('semanticHighlighting', true))
+            config.get<boolean>('restartAfterCrash') ? /*default*/ 4 : 0);
+    if (config.get<boolean>('semanticHighlighting'))
       semanticHighlighting.activate(this);
     this.client.registerFeature(new EnableEditsNearCursorFeature);
     typeHierarchy.activate(this);

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -5,7 +5,7 @@ import {ClangdContext} from './clangd-context';
 import * as config from './config';
 
 export function activate(context: ClangdContext) {
-  if (config.get<string>('onConfigChanged', 'prompt') != 'ignore') {
+  if (config.get<string>('onConfigChanged') !== 'ignore') {
     context.client.registerFeature(new ConfigFileWatcherFeature(context));
   }
 }
@@ -79,7 +79,7 @@ class ConfigFileWatcher implements vscode.Disposable {
     if ((await vscode.workspace.fs.stat(uri)).size <= 0)
       return;
 
-    switch (config.get<string>('onConfigChanged', 'prompt')) {
+    switch (config.get<string>('onConfigChanged')) {
     case 'restart':
       vscode.commands.executeCommand('clangd.restart');
       break;

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -5,7 +5,7 @@ import {ClangdContext} from './clangd-context';
 import * as config from './config';
 
 export function activate(context: ClangdContext) {
-  if (config.get<string>('onConfigChanged') != 'ignore') {
+  if (config.get<string>('onConfigChanged', 'prompt') != 'ignore') {
     context.client.registerFeature(new ConfigFileWatcherFeature(context));
   }
 }
@@ -30,8 +30,8 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
 }
 
 class ConfigFileWatcher implements vscode.Disposable {
-  private databaseWatcher: vscode.FileSystemWatcher = undefined;
-  private debounceTimer: NodeJS.Timer = undefined;
+  private databaseWatcher?: vscode.FileSystemWatcher;
+  private debounceTimer?: NodeJS.Timer;
 
   dispose() {
     if (this.databaseWatcher)
@@ -79,7 +79,7 @@ class ConfigFileWatcher implements vscode.Disposable {
     if ((await vscode.workspace.fs.stat(uri)).size <= 0)
       return;
 
-    switch (config.get<string>('onConfigChanged')) {
+    switch (config.get<string>('onConfigChanged', 'prompt')) {
     case 'restart':
       vscode.commands.executeCommand('clangd.restart');
       break;

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,9 +2,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Gets the config value `clangd.<key>`. Applies ${variable} substitutions.
-export function get<T>(key: string, defaultValue: T): T {
-  return substitute(
-      vscode.workspace.getConfiguration('clangd').get(key, defaultValue));
+export function get<T>(key: string): T {
+  return substitute(vscode.workspace.getConfiguration('clangd').get<T>(key)!);
 }
 
 // Like get(), but won't load settings from workspace config unless the user has
@@ -18,15 +17,15 @@ export function getSecure<T>(key: string, workspaceState: vscode.Memento): T|
 // Like get(), but won't implicitly load settings from workspace config.
 // If there is workspace config, prompts the user and caches the decision.
 export async function getSecureOrPrompt<T>(
-    key: string, workspaceState: vscode.Memento): Promise<T|undefined> {
+    key: string, workspaceState: vscode.Memento): Promise<T> {
   const prop = new SecureProperty<T>(key, workspaceState);
   // Common case: value not overridden in workspace.
   if (!prop.mismatched)
-    return prop.get(false);
+    return prop.get(false)!;
   // Check whether user has blessed or blocked this value.
   const blessed = prop.blessed;
-  if (blessed !== null)
-    return prop.get(blessed);
+  if (blessed !== undefined)
+    return prop.get(blessed)!;
   // No cached decision for this value, ask the user.
   const Yes = 'Yes, use this setting', No = 'No, use my default',
         Info = 'More Info'
@@ -41,11 +40,11 @@ export async function getSecureOrPrompt<T>(
     break;
   case Yes:
     await prop.bless(true);
-    return prop.get(true);
+    return prop.get(true)!;
   case No:
     await prop.bless(false);
   }
-  return prop.get(false);
+  return prop.get(false)!;
 }
 
 // Sets the config value `clangd.<key>`. Does not apply substitutions.
@@ -56,15 +55,14 @@ export function update<T>(key: string, value: T,
 
 // Traverse a JSON value, replacing placeholders in all strings.
 function substitute<T>(val: T): T {
-  if (typeof val == 'string') {
+  if (typeof val === 'string') {
     val = val.replace(/\$\{(.*?)\}/g, (match, name) => {
-      const rep = replacement(name);
       // If there's no replacement available, keep the placeholder.
-      return (rep === null) ? match : rep;
+      return replacement(name) ?? match;
     }) as unknown as T;
   } else if (Array.isArray(val))
     val = val.map((x) => substitute(x)) as unknown as T;
-  else if (typeof val == 'object') {
+  else if (typeof val === 'object') {
     // Substitute values but not keys, so we don't deal with collisions.
     const result = {} as {[k: string]: any};
     for (let [k, v] of Object.entries(val))
@@ -76,8 +74,9 @@ function substitute<T>(val: T): T {
 
 // Subset of substitution variables that are most likely to be useful.
 // https://code.visualstudio.com/docs/editor/variables-reference
-function replacement(name: string): string|null {
-  if (name == 'workspaceRoot' || name == 'workspaceFolder' || name == 'cwd') {
+function replacement(name: string): string|undefined {
+  if (name === 'workspaceRoot' || name === 'workspaceFolder' ||
+      name === 'cwd') {
     if (vscode.workspace.rootPath !== undefined)
       return vscode.workspace.rootPath;
     if (vscode.window.activeTextEditor !== undefined)
@@ -86,15 +85,15 @@ function replacement(name: string): string|null {
   }
   const envPrefix = 'env:';
   if (name.startsWith(envPrefix))
-    return process.env[name.substr(envPrefix.length)] || '';
+    return process.env[name.substr(envPrefix.length)] ?? '';
   const configPrefix = 'config:';
   if (name.startsWith(configPrefix)) {
     const config = vscode.workspace.getConfiguration().get(
         name.substr(configPrefix.length));
-    return (typeof config == 'string') ? config : null;
+    return (typeof config === 'string') ? config : undefined;
   }
 
-  return null;
+  return undefined;
 }
 
 // Caches a user's decision about whether to respect a workspace override of a
@@ -107,8 +106,8 @@ interface BlessCache {
 
 // Common logic between getSecure and getSecureOrPrompt.
 class SecureProperty<T> {
-  secure: T|undefined;
-  insecure: T|undefined;
+  secure?: T;
+  insecure?: T;
   public secureJSON: string;
   public insecureJSON: string;
   blessKey: string;
@@ -123,16 +122,16 @@ class SecureProperty<T> {
     this.blessKey = 'bless.' + key;
   }
 
-  get mismatched(): boolean { return this.secureJSON != this.insecureJSON; }
+  get mismatched(): boolean { return this.secureJSON !== this.insecureJSON; }
 
   get(trusted: boolean): T|undefined {
     return substitute(trusted ? this.insecure : this.secure);
   }
 
-  get blessed(): boolean|null {
+  get blessed(): boolean|undefined {
     let cache = this.workspaceState.get<BlessCache>(this.blessKey);
-    if (!cache || cache.json != this.insecureJSON)
-      return null;
+    if (!cache || cache.json !== this.insecureJSON)
+      return undefined;
     return cache.allowed;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,9 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Gets the config value `clangd.<key>`. Applies ${variable} substitutions.
-export function get<T>(key: string): T {
-  return substitute(vscode.workspace.getConfiguration('clangd').get(key));
+export function get<T>(key: string, defaultValue: T): T {
+  return substitute(
+      vscode.workspace.getConfiguration('clangd').get(key, defaultValue));
 }
 
 // Like get(), but won't load settings from workspace config unless the user has
@@ -17,7 +18,7 @@ export function getSecure<T>(key: string, workspaceState: vscode.Memento): T|
 // Like get(), but won't implicitly load settings from workspace config.
 // If there is workspace config, prompts the user and caches the decision.
 export async function getSecureOrPrompt<T>(
-    key: string, workspaceState: vscode.Memento): Promise<T> {
+    key: string, workspaceState: vscode.Memento): Promise<T|undefined> {
   const prop = new SecureProperty<T>(key, workspaceState);
   // Common case: value not overridden in workspace.
   if (!prop.mismatched)
@@ -114,7 +115,7 @@ class SecureProperty<T> {
 
   constructor(key: string, private workspaceState: vscode.Memento) {
     const cfg = vscode.workspace.getConfiguration('clangd');
-    const inspect = cfg.inspect<T>(key);
+    const inspect = cfg.inspect<T>(key)!;
     this.secure = inspect.globalValue ?? inspect.defaultValue;
     this.insecure = cfg.get<T>(key);
     this.secureJSON = JSON.stringify(this.secure);

--- a/src/file-status.ts
+++ b/src/file-status.ts
@@ -11,12 +11,12 @@ export function activate(context: ClangdContext) {
   context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(
       () => { status.updateStatus(); }));
   context.subscriptions.push(context.client.onDidChangeState(({newState}) => {
-    if (newState == vscodelc.State.Running) {
+    if (newState === vscodelc.State.Running) {
       // clangd starts or restarts after crash.
       context.client.onNotification(
           'textDocument/clangd.fileStatus',
           (fileStatus) => { status.onFileUpdated(fileStatus); });
-    } else if (newState == vscodelc.State.Stopped) {
+    } else if (newState === vscodelc.State.Stopped) {
       // Clear all cached statuses when clangd crashes.
       status.clear();
     }
@@ -43,7 +43,7 @@ class FileStatus {
     // Work around https://github.com/microsoft/vscode/issues/58869
     // Don't hide the status when activeTextEditor is output panel.
     // This aligns with the behavior of other panels, e.g. problems.
-    if (!activeDoc || activeDoc.uri.scheme == 'output')
+    if (!activeDoc || activeDoc.uri.scheme === 'output')
       return;
     const status = this.statuses.get(activeDoc.fileName);
     if (!status) {

--- a/src/file-status.ts
+++ b/src/file-status.ts
@@ -39,11 +39,11 @@ class FileStatus {
   }
 
   updateStatus() {
-    const activeDoc = vscode.window.activeTextEditor.document;
+    const activeDoc = vscode.window.activeTextEditor?.document;
     // Work around https://github.com/microsoft/vscode/issues/58869
     // Don't hide the status when activeTextEditor is output panel.
     // This aligns with the behavior of other panels, e.g. problems.
-    if (activeDoc.uri.scheme == 'output')
+    if (!activeDoc || activeDoc.uri.scheme == 'output')
       return;
     const status = this.statuses.get(activeDoc.fileName);
     if (!status) {

--- a/src/install.ts
+++ b/src/install.ts
@@ -21,8 +21,9 @@ export async function activate(
       'clangd.install', async () => common.installLatest(ui)));
   context.subscriptions.push(vscode.commands.registerCommand(
       'clangd.update', async () => common.checkUpdates(true, ui)));
-  const status = await common.prepare(ui, config.get<boolean>('checkUpdates'));
-  return status.clangdPath;
+  const status =
+      await common.prepare(ui, config.get<boolean>('checkUpdates', false));
+  return status.clangdPath ?? '';
 }
 
 class UI {
@@ -68,7 +69,7 @@ class UI {
         vscode.commands.registerCommand(name, body));
   }
 
-  async shouldReuse(release: string): Promise<boolean> {
+  async shouldReuse(release: string): Promise<boolean|undefined> {
     const message = `clangd ${release} is already installed!`;
     const use = 'Use the installed version';
     const reinstall = 'Delete it and reinstall';
@@ -126,7 +127,7 @@ class UI {
   }
 
   get clangdPath(): string {
-    let p = config.getSecure<string>('path', this.workspaceState);
+    let p = config.getSecure<string>('path', this.workspaceState)!;
     // Backwards compatibility: if it's a relative path with a slash, interpret
     // relative to project root.
     if (!path.isAbsolute(p) && p.indexOf(path.sep) != -1 &&

--- a/src/memory-usage.ts
+++ b/src/memory-usage.ts
@@ -51,9 +51,9 @@ function convert(m: WireTree, title: string): InternalTree {
 class MemoryUsageFeature implements vscodelc.StaticFeature {
   constructor(private context: ClangdContext) {
     const adapter = new TreeAdapter();
-    adapter.onDidChangeTreeData(
-        (e) => vscode.commands.executeCommand(
-            'setContext', 'clangd.memoryUsage.hasData', adapter.root != null));
+    adapter.onDidChangeTreeData((e) => vscode.commands.executeCommand(
+                                    'setContext', 'clangd.memoryUsage.hasData',
+                                    adapter.root !== undefined));
     this.context.subscriptions.push(
         vscode.window.registerTreeDataProvider('clangd.memoryUsage', adapter));
     this.context.subscriptions.push(

--- a/src/memory-usage.ts
+++ b/src/memory-usage.ts
@@ -63,7 +63,7 @@ class MemoryUsageFeature implements vscodelc.StaticFeature {
           adapter.root = convert(usage, '<root>');
         }));
     this.context.subscriptions.push(vscode.commands.registerCommand(
-        'clangd.memoryUsage.close', () => adapter.root = null));
+        'clangd.memoryUsage.close', () => adapter.root = undefined));
   }
 
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
@@ -80,8 +80,8 @@ class MemoryUsageFeature implements vscodelc.StaticFeature {
 class TreeAdapter implements vscode.TreeDataProvider<InternalTree> {
   private root_?: InternalTree;
 
-  get root(): InternalTree|null { return this.root_; }
-  set root(n: InternalTree|null) {
+  get root(): InternalTree|undefined { return this.root_; }
+  set root(n: InternalTree|undefined) {
     this.root_ = n;
     this._onDidChangeTreeData.fire(/*root changed*/ null);
   }

--- a/src/open-config.ts
+++ b/src/open-config.ts
@@ -7,7 +7,7 @@ import {ClangdContext} from './clangd-context';
 /**
  * @returns The path that corresponds to llvm::sys::path::user_config_directory.
  */
-function getUserConfigDirectory(): string {
+function getUserConfigDirectory(): string|undefined {
   switch (os.platform()) {
   case 'win32':
     if (process.env.LocalAppData)
@@ -24,13 +24,13 @@ function getUserConfigDirectory(): string {
       return path.join(process.env.HOME, '.config');
     break;
   }
-  return null;
+  return undefined;
 }
 
-function getUserConfigFile(): string {
+function getUserConfigFile(): string|undefined {
   const dir = getUserConfigDirectory();
   if (!dir)
-    return null;
+    return undefined;
   return path.join(dir, 'clangd', 'config.yaml');
 }
 
@@ -52,7 +52,7 @@ export function activate(context: ClangdContext) {
   // Create a command to open the project root .clangd configuration file.
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.projectConfig', () => {
-        if (vscode.workspace.workspaceFolders.length > 0) {
+        if (vscode.workspace.workspaceFolders?.length) {
           const folder = vscode.workspace.workspaceFolders[0];
           openConfigFile(vscode.Uri.joinPath(folder.uri, '.clangd'))
         } else {

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -61,9 +61,9 @@ const NotificationType =
 export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
   // The TextMate scope lookup table. A token with scope index i has the scopes
   // on index i in the lookup table.
-  scopeLookupTable: string[][];
+  scopeLookupTable!: string[][];
   // The object that applies the highlightings clangd sends.
-  highlighter: Highlighter;
+  highlighter!: Highlighter;
   // Any disposables that should be cleaned up when clangd crashes.
   private subscriptions: vscode.Disposable[] = [];
   constructor(context: ClangdContext) {
@@ -83,7 +83,7 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
     // capability to the object.
     const textDocumentCapabilities: vscodelc.TextDocumentClientCapabilities&
         {semanticHighlightingCapabilities?: {semanticHighlighting: boolean}} =
-        capabilities.textDocument;
+        capabilities.textDocument!;
     textDocumentCapabilities.semanticHighlightingCapabilities = {
       semanticHighlighting: true,
     };
@@ -92,7 +92,7 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
   async loadCurrentTheme() {
     const themeRuleMatcher = new ThemeRuleMatcher(
         await loadTheme(vscode.workspace.getConfiguration('workbench')
-                            .get<string>('colorTheme')));
+                            .get<string>('colorTheme', '')));
     this.highlighter.initialize(themeRuleMatcher);
   }
 
@@ -129,7 +129,7 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
 
   handleNotification(params: SemanticHighlightingParams) {
     const lines: SemanticHighlightingLine[] = params.lines.map(
-        (line) => ({line: line.line, tokens: decodeTokens(line.tokens)}));
+        (line) => ({line: line.line, tokens: decodeTokens(line.tokens ?? '')}));
     this.highlighter.highlight(vscode.Uri.parse(params.textDocument.uri),
                                lines);
   }
@@ -212,7 +212,7 @@ export class Highlighter {
     if (!this.files.has(fileUriStr)) {
       this.files.set(fileUriStr, new Map());
     }
-    const fileHighlightings = this.files.get(fileUriStr);
+    const fileHighlightings = this.files.get(fileUriStr)!;
     highlightingLines.forEach((line) => fileHighlightings.set(line.line, line));
     this.applyHighlights(fileUri);
   }
@@ -261,7 +261,7 @@ export class Highlighter {
       // useful for tests.
       return [];
     const lines: SemanticHighlightingLine[] =
-        Array.from(this.files.get(fileUriStr).values());
+        Array.from(this.files.get(fileUriStr)!.values());
     const decorations: vscode.Range[][] = this.decorationTypes.map(() => []);
     lines.forEach((line) => {
       line.tokens.forEach((token) => {
@@ -292,7 +292,7 @@ export class ThemeRuleMatcher {
   // Returns the best rule for a scope.
   getBestThemeRule(scope: string): TokenColorRule {
     if (this.bestRuleCache.has(scope))
-      return this.bestRuleCache.get(scope);
+      return this.bestRuleCache.get(scope)!;
     let bestRule: TokenColorRule = {scope: '', foreground: ''};
     this.themeRules.forEach((rule) => {
       // The best rule for a scope is the rule that is the longest prefix of the
@@ -344,10 +344,9 @@ function loadTheme(themeName: string): Promise<TokenColorRule[]> {
  * @param seenScopes A set containing the name of the scopes that have already
  *     been set.
  */
-export async function parseThemeFile(
-    fullPath: string, seenScopes?: Set<string>): Promise<TokenColorRule[]> {
-  if (!seenScopes)
-    seenScopes = new Set();
+export async function parseThemeFile(fullPath: string,
+                                     seenScopes: Set<string> =
+                                         new Set()): Promise<TokenColorRule[]> {
   // FIXME: Add support for themes written as .tmTheme.
   if (path.extname(fullPath) === '.tmTheme')
     return [];

--- a/src/semantic-highlighting.ts
+++ b/src/semantic-highlighting.ts
@@ -68,11 +68,11 @@ export class SemanticHighlightingFeature implements vscodelc.StaticFeature {
   private subscriptions: vscode.Disposable[] = [];
   constructor(context: ClangdContext) {
     context.subscriptions.push(context.client.onDidChangeState(({newState}) => {
-      if (newState == vscodelc.State.Running) {
+      if (newState === vscodelc.State.Running) {
         // Register handler for semantic highlighting notification.
         context.client.onNotification(NotificationType,
                                       this.handleNotification.bind(this));
-      } else if (newState == vscodelc.State.Stopped) {
+      } else if (newState === vscodelc.State.Stopped) {
         // Dispose resources when clangd crashes.
         this.dispose();
       }

--- a/src/switch-source-header.ts
+++ b/src/switch-source-header.ts
@@ -17,9 +17,9 @@ export const type =
 
 async function switchSourceHeader(client: vscodelc.LanguageClient):
     Promise<void> {
-  const uri = vscode.Uri.file(vscode.window.activeTextEditor.document.fileName);
-  if (!uri)
+  if (!vscode.window.activeTextEditor)
     return;
+  const uri = vscode.Uri.file(vscode.window.activeTextEditor.document.fileName);
 
   const docIdentifier = vscodelc.TextDocumentIdentifier.create(uri.toString());
   const sourceUri =

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -100,7 +100,7 @@ class TypeHierarchyTreeItem extends vscode.TreeItem {
 
 class TypeHierarchyFeature implements vscodelc.StaticFeature {
   private serverSupportsTypeHierarchy = false;
-  private state: vscodelc.State;
+  private state!: vscodelc.State;
 
   constructor(context: ClangdContext) {
     new TypeHierarchyProvider(context);
@@ -150,7 +150,7 @@ class TypeHierarchyProvider implements
 
   // The item on which the type hierarchy operation was invoked.
   // May be different from the root.
-  private startingItem: TypeHierarchyItem;
+  private startingItem!: TypeHierarchyItem;
 
   constructor(context: ClangdContext) {
     this.client = context.client;
@@ -237,7 +237,7 @@ class TypeHierarchyProvider implements
       return [this.root];
     if (this.direction == TypeHierarchyDirection.Parents) {
       // Clangd always resolves parents eagerly, so just return them.
-      return element.parents;
+      return element.parents ?? [];
     }
     // Otherwise, this.direction == Children.
     if (!element.children) {
@@ -248,9 +248,9 @@ class TypeHierarchyProvider implements
             direction: TypeHierarchyDirection.Children,
             resolve: 1
           });
-      element.children = resolved.children;
+      element.children = resolved?.children;
     }
-    return element.children;
+    return element.children ?? [];
   }
 
   private computeRoot(): TypeHierarchyItem {

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -74,7 +74,7 @@ class TypeHierarchyTreeItem extends vscode.TreeItem {
   constructor(item: TypeHierarchyItem) {
     super(item.name);
     if (item.children) {
-      if (item.children.length == 0) {
+      if (item.children.length === 0) {
         this.collapsibleState = vscode.TreeItemCollapsibleState.None;
       } else {
         this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
@@ -84,7 +84,7 @@ class TypeHierarchyTreeItem extends vscode.TreeItem {
     }
 
     // Do not register actions for the dummy node.
-    if (item == dummyNode) {
+    if (item === dummyNode) {
       return;
     }
 
@@ -125,10 +125,10 @@ class TypeHierarchyFeature implements vscodelc.StaticFeature {
   dispose() {}
 
   private recomputeEnableTypeHierarchy() {
-    if (this.state == vscodelc.State.Running) {
+    if (this.state === vscodelc.State.Running) {
       vscode.commands.executeCommand('setContext', 'clangd.enableTypeHierarchy',
                                      this.serverSupportsTypeHierarchy);
-    } else if (this.state == vscodelc.State.Stopped) {
+    } else if (this.state === vscodelc.State.Stopped) {
       vscode.commands.executeCommand('setContext', 'clangd.enableTypeHierarchy',
                                      false);
     }
@@ -220,7 +220,7 @@ class TypeHierarchyProvider implements
     // This function is implemented so that VSCode lets us call
     // this.treeView.reveal().
     if (element.parents) {
-      if (element.parents.length == 1) {
+      if (element.parents.length === 1) {
         return element.parents[0];
       } else if (element.parents.length > 1) {
         return dummyNode;
@@ -235,11 +235,11 @@ class TypeHierarchyProvider implements
       return [];
     if (!element)
       return [this.root];
-    if (this.direction == TypeHierarchyDirection.Parents) {
+    if (this.direction === TypeHierarchyDirection.Parents) {
       // Clangd always resolves parents eagerly, so just return them.
       return element.parents ?? [];
     }
-    // Otherwise, this.direction == Children.
+    // Otherwise, this.direction === Children.
     if (!element.children) {
       // Children are not resolved yet, resolve them now.
       const resolved =
@@ -255,7 +255,7 @@ class TypeHierarchyProvider implements
 
   private computeRoot(): TypeHierarchyItem {
     // In Parents mode, the root is always the starting item.
-    if (this.direction == TypeHierarchyDirection.Parents) {
+    if (this.direction === TypeHierarchyDirection.Parents) {
       return this.startingItem;
     }
 
@@ -264,7 +264,7 @@ class TypeHierarchyProvider implements
     // with multiple bases, we show a dummy node with the label
     // "[multiple parents]" instead.
     let root = this.startingItem;
-    while (root.parents && root.parents.length == 1) {
+    while (root.parents && root.parents.length === 1) {
       root = root.parents[0];
     }
     if (root.parents && root.parents.length > 1) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         ],
         "sourceMap": true,
         "rootDir": ".",
-        "alwaysStrict": true,
+        "strict": true,
         "noEmitOnError": true,
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,


### PR DESCRIPTION
Closes #61.

Changes have been made to adhere to strict type checking:
- Non-null assertions and definite-assignment assertions (`!` post-fix operator) have been added to please the compiler (these do not affect the compiled output). These assertions are not always strictly "safe", but are not any less safe than not having strict type checking at all. Plus, their presence in the code can be a signal that maybe the design should be changed to safely ensure that the types are not null/undefined.
- Some optional chaining (`?.`) has been been added when properties can be null/undefined.
- Some incorrect uses of `null` have been replaced with `undefined`.
- Add `defaultValue` arguments to `WorkspaceConfiguration.get()` so that it will not return undefined. The default values being passed are the default values defined in the package.json. Realistically, the function should not return undefined when default values are defined in the package.json, but this pleases the compiler.

The changes I've made were aimed at not changing the behavior of the extension, and weren't necessarily aimed at fixing any potential bugs. Strict type checking will make it less likely to introduce new bugs in future changes.