### PR TITLE
Add commands to open global and project config

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,16 @@
                 "command": "clangd.ast.close",
                 "title": "Close",
                 "icon": "$(panel-close)"
+            },
+            {
+                "command": "clangd.projectSettings",
+                "title": "clangd: Open Project Settings",
+                "icon": "$(gear)"
+            },
+            {
+                "command": "clangd.globalSettings",
+                "title": "clangd: Open Global Settings",
+                "icon": "$(gear)"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -214,13 +214,13 @@
                 "icon": "$(panel-close)"
             },
             {
-                "command": "clangd.projectSettings",
-                "title": "clangd: Open Project Settings",
+                "command": "clangd.projectConfig",
+                "title": "clangd: Open project configuration file",
                 "icon": "$(gear)"
             },
             {
-                "command": "clangd.globalSettings",
-                "title": "clangd: Open Global Settings",
+                "command": "clangd.userConfig",
+                "title": "clangd: Open user configuration file",
                 "icon": "$(gear)"
             }
         ],

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -7,6 +7,7 @@ import * as configFileWatcher from './config-file-watcher';
 import * as fileStatus from './file-status';
 import * as install from './install';
 import * as memoryUsage from './memory-usage';
+import * as openConfig from './open-config';
 import * as semanticHighlighting from './semantic-highlighting';
 import * as switchSourceHeader from './switch-source-header';
 import * as typeHierarchy from './type-hierarchy';
@@ -150,6 +151,7 @@ export class ClangdContext implements vscode.Disposable {
     typeHierarchy.activate(this);
     memoryUsage.activate(this);
     ast.activate(this);
+    openConfig.activate(this);
     this.subscriptions.push(this.client.start());
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 
 import {ClangdContext} from './clangd-context';
-import * as OpenConfig from './open-config';
 
 /**
  *  This method is called when the extension is activated. The extension is
@@ -24,8 +23,6 @@ export async function activate(context: vscode.ExtensionContext) {
         await clangdContext.activate(context.globalStoragePath, outputChannel,
                                      context.workspaceState);
       }));
-
-  OpenConfig.activate(context);
 
   await clangdContext.activate(context.globalStoragePath, outputChannel,
                                context.workspaceState);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,51 @@
+import * as os from 'os'
+import * as path from 'path'
 import * as vscode from 'vscode';
 
 import {ClangdContext} from './clangd-context';
+
+function getConfigFolder(): string {
+  switch (os.platform()) {
+  case 'win32':
+    if (process.env.LocalAppData)
+      return process.env.LocalAppData;
+    break;
+  case 'darwin':
+    if (process.env.HOME)
+      return path.join(process.env.HOME, 'Library', 'Preferences');
+    break;
+  case 'linux':
+    if (process.env.XDG_CONFIG_HOME)
+      return process.env.XDG_CONFIG_HOME;
+    if (process.env.HOME)
+      return path.join(process.env.HOME, '.config');
+    break;
+  default:
+    break;
+  }
+  return null;
+}
+
+function getConfigFile(): string {
+  const Folder = getConfigFolder();
+  if (!Folder)
+    return null;
+  return path.join(Folder, 'clangd', 'config.yaml');
+}
+
+async function openConfigFile(path: vscode.Uri) {
+  let p = path;
+  try {
+    await vscode.workspace.fs.stat(path);
+  } catch {
+    // File doesn't exist, create a scratch file.
+    p = path.with({scheme: 'untitled'});
+  }
+  vscode.workspace.openTextDocument(p).then((a => {
+    vscode.languages.setTextDocumentLanguage(a, 'yaml');
+    vscode.window.showTextDocument(a);
+  }));
+}
 
 /**
  *  This method is called when the extension is activated. The extension is
@@ -22,6 +67,28 @@ export async function activate(context: vscode.ExtensionContext) {
         await clangdContext.dispose();
         await clangdContext.activate(context.globalStoragePath, outputChannel,
                                      context.workspaceState);
+      }));
+
+  // Create a command to open the project root .clangd configuration file.
+  context.subscriptions.push(
+      vscode.commands.registerCommand('clangd.projectSettings', () => {
+        if (vscode.workspace.workspaceFolders) {
+          const folder = vscode.workspace.workspaceFolders[0];
+          openConfigFile(vscode.Uri.joinPath(folder.uri, '.clangd'))
+        } else {
+          vscode.window.showErrorMessage('No project is open');
+        }
+      }));
+
+  context.subscriptions.push(
+      vscode.commands.registerCommand('clangd.globalSettings', () => {
+        const file = getConfigFile();
+        if (file) {
+          openConfigFile(vscode.Uri.file(file));
+        } else {
+          vscode.window.showErrorMessage(
+              'Couldn\'t get global configuration directory');
+        }
       }));
 
   await clangdContext.activate(context.globalStoragePath, outputChannel,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,51 +1,7 @@
-import * as os from 'os'
-import * as path from 'path'
 import * as vscode from 'vscode';
 
 import {ClangdContext} from './clangd-context';
-
-function getConfigFolder(): string {
-  switch (os.platform()) {
-  case 'win32':
-    if (process.env.LocalAppData)
-      return process.env.LocalAppData;
-    break;
-  case 'darwin':
-    if (process.env.HOME)
-      return path.join(process.env.HOME, 'Library', 'Preferences');
-    break;
-  case 'linux':
-    if (process.env.XDG_CONFIG_HOME)
-      return process.env.XDG_CONFIG_HOME;
-    if (process.env.HOME)
-      return path.join(process.env.HOME, '.config');
-    break;
-  default:
-    break;
-  }
-  return null;
-}
-
-function getConfigFile(): string {
-  const Folder = getConfigFolder();
-  if (!Folder)
-    return null;
-  return path.join(Folder, 'clangd', 'config.yaml');
-}
-
-async function openConfigFile(path: vscode.Uri) {
-  let p = path;
-  try {
-    await vscode.workspace.fs.stat(path);
-  } catch {
-    // File doesn't exist, create a scratch file.
-    p = path.with({scheme: 'untitled'});
-  }
-  vscode.workspace.openTextDocument(p).then((a => {
-    vscode.languages.setTextDocumentLanguage(a, 'yaml');
-    vscode.window.showTextDocument(a);
-  }));
-}
+import * as OpenConfig from './open-config';
 
 /**
  *  This method is called when the extension is activated. The extension is
@@ -69,27 +25,7 @@ export async function activate(context: vscode.ExtensionContext) {
                                      context.workspaceState);
       }));
 
-  // Create a command to open the project root .clangd configuration file.
-  context.subscriptions.push(
-      vscode.commands.registerCommand('clangd.projectSettings', () => {
-        if (vscode.workspace.workspaceFolders) {
-          const folder = vscode.workspace.workspaceFolders[0];
-          openConfigFile(vscode.Uri.joinPath(folder.uri, '.clangd'))
-        } else {
-          vscode.window.showErrorMessage('No project is open');
-        }
-      }));
-
-  context.subscriptions.push(
-      vscode.commands.registerCommand('clangd.globalSettings', () => {
-        const file = getConfigFile();
-        if (file) {
-          openConfigFile(vscode.Uri.file(file));
-        } else {
-          vscode.window.showErrorMessage(
-              'Couldn\'t get global configuration directory');
-        }
-      }));
+  OpenConfig.activate(context);
 
   await clangdContext.activate(context.globalStoragePath, outputChannel,
                                context.workspaceState);

--- a/src/open-config.ts
+++ b/src/open-config.ts
@@ -2,6 +2,8 @@ import * as os from 'os'
 import * as path from 'path'
 import * as vscode from 'vscode';
 
+import {ClangdContext} from './clangd-context';
+
 /**
  * @returns The path that corresponds to llvm::sys::path::user_config_directory.
  */
@@ -46,7 +48,7 @@ async function openConfigFile(path: vscode.Uri) {
   }));
 }
 
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: ClangdContext) {
   // Create a command to open the project root .clangd configuration file.
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.projectConfig', () => {

--- a/src/open-config.ts
+++ b/src/open-config.ts
@@ -1,0 +1,71 @@
+import * as os from 'os'
+import * as path from 'path'
+import * as vscode from 'vscode';
+
+/**
+ * @returns The path that corresponds to llvm::sys::path::user_config_directory.
+ */
+function getUserConfigDirectory(): string {
+  switch (os.platform()) {
+  case 'win32':
+    if (process.env.LocalAppData)
+      return process.env.LocalAppData;
+    break;
+  case 'darwin':
+    if (process.env.HOME)
+      return path.join(process.env.HOME, 'Library', 'Preferences');
+    break;
+  default:
+    if (process.env.XDG_CONFIG_HOME)
+      return process.env.XDG_CONFIG_HOME;
+    if (process.env.HOME)
+      return path.join(process.env.HOME, '.config');
+    break;
+  }
+  return null;
+}
+
+function getUserConfigFile(): string {
+  const dir = getUserConfigDirectory();
+  if (!dir)
+    return null;
+  return path.join(dir, 'clangd', 'config.yaml');
+}
+
+async function openConfigFile(path: vscode.Uri) {
+  let p = path;
+  try {
+    await vscode.workspace.fs.stat(path);
+  } catch {
+    // File doesn't exist, create a scratch file.
+    p = path.with({scheme: 'untitled'});
+  }
+  vscode.workspace.openTextDocument(p).then((a => {
+    vscode.languages.setTextDocumentLanguage(a, 'yaml');
+    vscode.window.showTextDocument(a);
+  }));
+}
+
+export function activate(context: vscode.ExtensionContext) {
+  // Create a command to open the project root .clangd configuration file.
+  context.subscriptions.push(
+      vscode.commands.registerCommand('clangd.projectConfig', () => {
+        if (vscode.workspace.workspaceFolders.length > 0) {
+          const folder = vscode.workspace.workspaceFolders[0];
+          openConfigFile(vscode.Uri.joinPath(folder.uri, '.clangd'))
+        } else {
+          vscode.window.showErrorMessage('No project is open');
+        }
+      }));
+
+  context.subscriptions.push(
+      vscode.commands.registerCommand('clangd.userConfig', () => {
+        const file = getUserConfigFile();
+        if (file) {
+          openConfigFile(vscode.Uri.file(file));
+        } else {
+          vscode.window.showErrorMessage(
+              'Couldn\'t get global configuration directory');
+        }
+      }));
+}


### PR DESCRIPTION
Global config opening will likely not work on remote setups and is as of yet untested on windows and mac builds.

Fixes #176 