### PR TITLE
Improve presentation of inactive region highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Next (not yet released)
+
+* Combine inactive region style with client-side (textmate) token colors [#193](https://github.com/clangd/vscode-clangd/pull/193).
+  Requires clangd 17 or later.
+  * The default inactive region style is reduced opacity. The opacity level can be
+    customized with `clangd.inactiveRegions.opacity`.
+  * An alternative inactive region style of a background highlight can be enabled with
+    `clangd.inactiveRegions.useBackgroundHighlight=true`. The highlight color can be
+    customized with `clangd.inactiveRegions.background` in `workbench.colorCustomizations`.
+
 ## Version 0.1.24: April 21, 2023
 
 - Fix an undefined object access in ClangdContext.dispose() [#461](https://github.com/clangd/vscode-clangd/pull/461)

--- a/package.json
+++ b/package.json
@@ -157,9 +157,30 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Warn about conflicting extensions and suggest disabling them."
+                },
+                "clangd.inactiveRegions.useBackgroundHighlight": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use a background highlight rather than opacity to identify inactive preprocessor regions."
+                },
+                "clangd.inactiveRegions.opacity": {
+                    "type": "number",
+                    "default": 0.55,
+                    "description": "Opacity of inactive regions (used only if clangd.inactiveRegions.useBackgroundHighlight=false)"
                 }
             }
         },
+        "colors": [
+            {
+                "id": "clangd.inactiveRegions.background",
+                "description": "Background color of inactive code regions (used only if clangd.inactiveRegions.useBackgroundHighlight=true)",
+                "defaults": {
+                    "dark": "#1212124C",
+                    "light": "#DCDCDC4C",
+                    "highContrast": "#FCFCFC4C"
+                }
+            }
+        ],
         "commands": [
             {
                 "command": "clangd.switchheadersource",

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -5,6 +5,7 @@ import * as ast from './ast';
 import * as config from './config';
 import * as configFileWatcher from './config-file-watcher';
 import * as fileStatus from './file-status';
+import * as inactiveRegions from './inactive-regions';
 import * as inlayHints from './inlay-hints';
 import * as install from './install';
 import * as memoryUsage from './memory-usage';
@@ -161,6 +162,7 @@ export class ClangdContext implements vscode.Disposable {
     memoryUsage.activate(this);
     ast.activate(this);
     openConfig.activate(this);
+    inactiveRegions.activate(this);
     this.client.start();
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);

--- a/src/inactive-regions.ts
+++ b/src/inactive-regions.ts
@@ -1,0 +1,108 @@
+import * as vscode from 'vscode';
+import * as vscodelc from 'vscode-languageclient/node';
+
+import {ClangdContext} from './clangd-context';
+import * as config from './config';
+
+// Parameters for the inactive regions (server-side) push notification.
+interface InactiveRegionsParams {
+  // The text document that has to be decorated with the inactive regions
+  // information.
+  textDocument: vscodelc.VersionedTextDocumentIdentifier;
+  // An array of inactive regions.
+  regions: vscodelc.Range[];
+}
+
+// Language server push notification providing the inactive regions
+// information for a text document.
+export const NotificationType =
+    new vscodelc.NotificationType<InactiveRegionsParams>(
+        'textDocument/inactiveRegions');
+
+export function activate(context: ClangdContext) {
+  const feature = new InactiveRegionsFeature(context);
+  context.client.registerFeature(feature);
+  context.client.onNotification(NotificationType,
+                                feature.handleNotification.bind(feature));
+}
+
+export class InactiveRegionsFeature implements vscodelc.StaticFeature {
+  private decorationType?: vscode.TextEditorDecorationType;
+  private files: Map<string, vscode.Range[]> = new Map();
+  private context: ClangdContext;
+
+  constructor(context: ClangdContext) { this.context = context; }
+
+  fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {
+    // Extend the ClientCapabilities type and add inactive regions
+    // capability to the object.
+    if (capabilities.textDocument) {
+      const textDocumentCapabilities: vscodelc.TextDocumentClientCapabilities&
+          {inactiveRegionsCapabilities?: {inactiveRegions: boolean}} =
+          capabilities.textDocument;
+      textDocumentCapabilities.inactiveRegionsCapabilities = {
+        inactiveRegions: true,
+      };
+    }
+  }
+  initialize(capabilities: vscodelc.ServerCapabilities,
+             documentSelector: vscodelc.DocumentSelector|undefined) {
+    const serverCapabilities: vscodelc.ServerCapabilities&
+        {inactiveRegionsProvider?: any} = capabilities;
+    if (serverCapabilities.inactiveRegionsProvider) {
+      if (config.get<boolean>('inactiveRegions.useBackgroundHighlight')) {
+        this.decorationType = vscode.window.createTextEditorDecorationType({
+          isWholeLine: true,
+          backgroundColor:
+              new vscode.ThemeColor('clangd.inactiveRegions.background'),
+        });
+      } else {
+        this.decorationType = vscode.window.createTextEditorDecorationType({
+          isWholeLine: true,
+          opacity: config.get<number>('inactiveRegions.opacity').toString()
+        });
+      }
+      this.context.subscriptions.push(
+          vscode.window.onDidChangeVisibleTextEditors(
+              (editors) => editors.forEach(
+                  (e) => this.applyHighlights(e.document.uri.toString()))));
+      this.context.subscriptions.push(
+          vscode.workspace.onDidChangeConfiguration((conf) => {
+            if (!conf.affectsConfiguration('workbench.colorTheme'))
+              return;
+            vscode.window.visibleTextEditors.forEach((e) => {
+              if (!this.decorationType)
+                return;
+              const ranges = this.files.get(e.document.uri.toString());
+              if (!ranges)
+                return;
+              e.setDecorations(this.decorationType, ranges);
+            });
+          }));
+    }
+  }
+
+  handleNotification(params: InactiveRegionsParams) {
+    const fileUri = params.textDocument.uri;
+    const ranges: vscode.Range[] = params.regions.map(
+        (r) => this.context.client.protocol2CodeConverter.asRange(r));
+    this.files.set(fileUri, ranges);
+    this.applyHighlights(fileUri);
+  }
+
+  applyHighlights(fileUri: string) {
+    const ranges = this.files.get(fileUri);
+    if (!ranges)
+      return;
+    vscode.window.visibleTextEditors.forEach((e) => {
+      if (!this.decorationType)
+        return;
+      if (e.document.uri.toString() !== fileUri)
+        return;
+      e.setDecorations(this.decorationType, ranges);
+    });
+  }
+
+  getState(): vscodelc.FeatureState { return {kind: 'static'}; }
+  dispose() {}
+}


### PR DESCRIPTION
This patch intercepts the semantic tokens requests using middleware,
extracts the inactive code ranges, and uses setDecorations() to
provide whole-line background highlighting for them.