### PR TITLE
Add option to suppress warning about the Microsoft C/C++ extension incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
                         "Automatically restart the server",
                         "Do nothing"
                     ]
+                },
+                "clangd.detectAndDisableExtensionConflicts": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to look for extension conflicts and disable any conflicting settings."
                 }
             }
         },
@@ -317,24 +322,24 @@
             ]
         },
         "colors": [
-          {
-            "id": "clangd.inlayHints.foreground",
-            "description": "Foreground color of inlay hints",
-            "defaults": {
-              "dark": "#A0A0A0F0",
-              "light": "#747474",
-              "highContrast": "#BEBEBE"
+            {
+                "id": "clangd.inlayHints.foreground",
+                "description": "Foreground color of inlay hints",
+                "defaults": {
+                    "dark": "#A0A0A0F0",
+                    "light": "#747474",
+                    "highContrast": "#BEBEBE"
+                }
+            },
+            {
+                "id": "clangd.inlayHints.background",
+                "description": "Background color of inlay hints",
+                "defaults": {
+                    "dark": "#11223300",
+                    "light": "#11223300",
+                    "highContrast": "#11223300"
+                }
             }
-          },
-          {
-            "id": "clangd.inlayHints.background",
-            "description": "Background color of inlay hints",
-            "defaults": {
-              "dark": "#11223300",
-              "light": "#11223300",
-              "highContrast": "#11223300"
-            }
-          }
         ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -322,24 +322,24 @@
             ]
         },
         "colors": [
-            {
-                "id": "clangd.inlayHints.foreground",
-                "description": "Foreground color of inlay hints",
-                "defaults": {
-                    "dark": "#A0A0A0F0",
-                    "light": "#747474",
-                    "highContrast": "#BEBEBE"
-                }
-            },
-            {
-                "id": "clangd.inlayHints.background",
-                "description": "Background color of inlay hints",
-                "defaults": {
-                    "dark": "#11223300",
-                    "light": "#11223300",
-                    "highContrast": "#11223300"
-                }
+          {
+            "id": "clangd.inlayHints.foreground",
+            "description": "Foreground color of inlay hints",
+            "defaults": {
+              "dark": "#A0A0A0F0",
+              "light": "#747474",
+              "highContrast": "#BEBEBE"
             }
+          },
+          {
+            "id": "clangd.inlayHints.background",
+            "description": "Background color of inlay hints",
+            "defaults": {
+              "dark": "#11223300",
+              "light": "#11223300",
+              "highContrast": "#11223300"
+            }
+          }
         ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -149,10 +149,10 @@
                         "Do nothing"
                     ]
                 },
-                "clangd.detectAndDisableExtensionConflicts": {
+                "clangd.detectExtensionConflicts": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Whether to look for extension conflicts and disable any conflicting settings."
+                    "description": "Warn about conflicting extensions and suggest disabling them."
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,14 +27,14 @@ export async function activate(context: vscode.ExtensionContext) {
   await clangdContext.activate(context.globalStoragePath, outputChannel,
                                context.workspaceState);
 
-  const shouldCheck = vscode.workspace
-    .getConfiguration("clangd")
-    .get("detectAndDisableExtensionConflicts");
+  const shouldCheck = vscode.workspace.getConfiguration('clangd').get(
+      'detectExtensionConflicts');
   if (shouldCheck) {
-    setInterval(function() {
+    const interval = setInterval(function() {
       const cppTools = vscode.extensions.getExtension('ms-vscode.cpptools');
       if (cppTools && cppTools.isActive) {
-        const cppToolsConfiguration = vscode.workspace.getConfiguration('C_Cpp');
+        const cppToolsConfiguration =
+            vscode.workspace.getConfiguration('C_Cpp');
         const cppToolsEnabled = cppToolsConfiguration.get('intelliSenseEngine');
         if (cppToolsEnabled !== 'Disabled') {
           vscode.window
@@ -42,10 +42,18 @@ export async function activate(context: vscode.ExtensionContext) {
                   'You have both the Microsoft C++ (cpptools) extension and ' +
                       'clangd extension enabled. The Microsoft IntelliSense features ' +
                       'conflict with clangd\'s code completion, diagnostics etc.',
-                  'Disable IntelliSense')
-              .then(_ => {
-                cppToolsConfiguration.update('intelliSenseEngine', 'Disabled',
-                                            vscode.ConfigurationTarget.Global);
+                  'Disable IntelliSense', 'Never show this warning')
+              .then(selection => {
+                if (selection == 'Disable IntelliSense') {
+                  cppToolsConfiguration.update(
+                      'intelliSenseEngine', 'Disabled',
+                      vscode.ConfigurationTarget.Global);
+                } else if (selection == 'Never show this warning') {
+                  vscode.workspace.getConfiguration('clangd').update(
+                      'detectExtensionConflicts', false,
+                      vscode.ConfigurationTarget.Global);
+                  clearInterval(interval);
+                }
               });
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,23 +27,28 @@ export async function activate(context: vscode.ExtensionContext) {
   await clangdContext.activate(context.globalStoragePath, outputChannel,
                                context.workspaceState);
 
-  setInterval(function() {
-    const cppTools = vscode.extensions.getExtension('ms-vscode.cpptools');
-    if (cppTools && cppTools.isActive) {
-      const cppToolsConfiguration = vscode.workspace.getConfiguration('C_Cpp');
-      const cppToolsEnabled = cppToolsConfiguration.get('intelliSenseEngine');
-      if (cppToolsEnabled !== 'Disabled') {
-        vscode.window
-            .showWarningMessage(
-                'You have both the Microsoft C++ (cpptools) extension and ' +
-                    'clangd extension enabled. The Microsoft IntelliSense features ' +
-                    'conflict with clangd\'s code completion, diagnostics etc.',
-                'Disable IntelliSense')
-            .then(_ => {
-              cppToolsConfiguration.update('intelliSenseEngine', 'Disabled',
-                                           vscode.ConfigurationTarget.Global);
-            });
+  const shouldCheck = vscode.workspace
+    .getConfiguration("clangd")
+    .get("detectAndDisableExtensionConflicts");
+  if (shouldCheck) {
+    setInterval(function() {
+      const cppTools = vscode.extensions.getExtension('ms-vscode.cpptools');
+      if (cppTools && cppTools.isActive) {
+        const cppToolsConfiguration = vscode.workspace.getConfiguration('C_Cpp');
+        const cppToolsEnabled = cppToolsConfiguration.get('intelliSenseEngine');
+        if (cppToolsEnabled !== 'Disabled') {
+          vscode.window
+              .showWarningMessage(
+                  'You have both the Microsoft C++ (cpptools) extension and ' +
+                      'clangd extension enabled. The Microsoft IntelliSense features ' +
+                      'conflict with clangd\'s code completion, diagnostics etc.',
+                  'Disable IntelliSense')
+              .then(_ => {
+                cppToolsConfiguration.update('intelliSenseEngine', 'Disabled',
+                                            vscode.ConfigurationTarget.Global);
+              });
+        }
       }
-    }
-  }, 5000);
+    }, 5000);
+  }
 }


### PR DESCRIPTION
I've added an option to control suppression of the incompatibility warning (and not change the C/C++ settings).

I'm making this pull request as suggested in https://github.com/clangd/vscode-clangd/issues/162, since others seem to have faced this same issue.