### PR TITLE
Tag releases and upload VSIX in autorelease workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,4 @@
-name: Publish to VSCode marketplace
+name: Publish release
 on:
   push:
     branches: [ master ]
@@ -20,9 +20,19 @@ jobs:
       run: npm ci
     - if: steps.check.outputs.changed == 'true'
       run: npm test
-    - name: publish
+    - name: package
+      if: steps.check.outputs.changed == 'true'
+      run: npm run package
+    - name: publish to Github
+      uses: ncipollo/release-action@v1
+      if: steps.check.outputs.changed == 'true'
+      with:
+        artifacts: "vscode-clangd-*.vsix"
+        tag: ${{ steps.check.outputs.version }}
+        commit: ${{ steps.check.outputs.commit }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: publish to VSCode Marketplace
       if: steps.check.outputs.changed == 'true'
       # The token will be expired in on 01/10/2022. Regenerate it at
       # https://llvm-vs-code-extensions.visualstudio.com/_usersSettings/tokens.
       run: npm run publish -- -p "${{ secrets.VSCODE_MARKETPLACE_TOKEN }}"
-


### PR DESCRIPTION
Tested on my fork:

https://github.com/sam-mccall/vscode-clangd/releases/tag/0.1.13-foo