### PR TITLE
Add switch header/source to editor context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,6 +254,7 @@
                 },
                 {
                     "command": "clangd.switchheadersource",
+                    "when": "resourceLangId == cpp",
                     "group": "0_navigation@5"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -252,10 +252,10 @@
                     "group": "0_navigation@4",
                     "_comment": "see https://github.com/microsoft/vscode-references-view/blob/f63eaed9934ca5ecc8f3fb3ca096f38c6e5e181f/package.json#L162"
                 },
-		{
-		    "command": "clangd.switchheadersource",
-		    "group": "0_navigation@5"
-		},
+                {
+                    "command": "clangd.switchheadersource",
+                    "group": "0_navigation@5"
+                },
                 {
                     "command": "clangd.ast",
                     "when": "clangd.ast.supported"

--- a/package.json
+++ b/package.json
@@ -252,6 +252,10 @@
                     "group": "0_navigation@4",
                     "_comment": "see https://github.com/microsoft/vscode-references-view/blob/f63eaed9934ca5ecc8f3fb3ca096f38c6e5e181f/package.json#L162"
                 },
+		{
+		    "command": "clangd.switchheadersource",
+		    "group": "0_navigation@5"
+		},
                 {
                     "command": "clangd.ast",
                     "when": "clangd.ast.supported"


### PR DESCRIPTION
Fixes #244.

Note that this displays "clangd: switch between source/header" in the context menu. The "clangd" prefix doesn't look good, but I can't seem to fix that without changing the title of the command (which also affects what one sees in the command palette). I'm not sure what's the best option.