### PR TITLE
enable switchheadersource for all langs, and add category to all commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,7 +254,6 @@
                 },
                 {
                     "command": "clangd.switchheadersource",
-                    "when": "resourceLangId == cpp",
                     "group": "0_navigation@5"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
             {
                 "command": "clangd.switchheadersource",
                 "category": "clangd",
-                "title": "Switch Source/Header"
+                "title": "Switch Between Source/Header"
             },
             {
                 "command": "clangd.install",

--- a/package.json
+++ b/package.json
@@ -161,73 +161,88 @@
         "commands": [
             {
                 "command": "clangd.switchheadersource",
-                "title": "clangd: Switch between source/header"
+                "category": "clangd",
+                "title": "Switch Source/Header"
             },
             {
                 "command": "clangd.install",
-                "title": "clangd: Download language server"
+                "category": "clangd",
+                "title": "Download language server"
             },
             {
                 "command": "clangd.update",
-                "title": "clangd: Check for language server update"
+                "category": "clangd",
+                "title": "Check for language server update"
             },
             {
                 "command": "clangd.activate",
-                "title": "clangd: Manually activate extension"
+                "category": "clangd",
+                "title": "Manually activate extension"
             },
             {
                 "command": "clangd.restart",
-                "title": "clangd: Restart language server"
+                "category": "clangd",
+                "title": "Restart language server"
             },
             {
                 "command": "clangd.typeHierarchy",
+                "category": "clangd",
                 "title": "Open Type Hierarchy"
             },
             {
                 "command": "clangd.typeHierarchy.viewParents",
+                "category": "clangd",
                 "title": "Types: Show Base Classes",
                 "icon": "$(triangle-up)"
             },
             {
                 "command": "clangd.typeHierarchy.viewChildren",
+                "category": "clangd",
                 "title": "Types: Show Derived Classes",
                 "icon": "$(triangle-down)"
             },
             {
                 "command": "clangd.typeHierarchy.close",
+                "category": "clangd",
                 "title": "Close",
                 "icon": "$(panel-close)"
             },
             {
                 "command": "clangd.memoryUsage",
-                "title": "clangd: Show memory usage",
+                "category": "clangd",
+                "title": "Show memory usage",
                 "enablement": "clangd.memoryUsage.supported",
                 "icon": "$(refresh)"
             },
             {
                 "command": "clangd.memoryUsage.close",
+                "category": "clangd",
                 "title": "Close",
                 "icon": "$(panel-close)"
             },
             {
                 "command": "clangd.ast",
+                "category": "clangd",
                 "title": "Show AST",
                 "enablement": "clangd.ast.supported",
                 "icon": "$(list-tree)"
             },
             {
                 "command": "clangd.ast.close",
+                "category": "clangd",
                 "title": "Close",
                 "icon": "$(panel-close)"
             },
             {
                 "command": "clangd.projectConfig",
-                "title": "clangd: Open project configuration file",
+                "category": "clangd",
+                "title": "Open project configuration file",
                 "icon": "$(gear)"
             },
             {
                 "command": "clangd.userConfig",
-                "title": "clangd: Open user configuration file",
+                "category": "clangd",
+                "title": "Open user configuration file",
                 "icon": "$(gear)"
             }
         ],
@@ -254,7 +269,7 @@
                 },
                 {
                     "command": "clangd.switchheadersource",
-                    "group": "0_navigation@5"
+                    "group": "navigation@5"
                 },
                 {
                     "command": "clangd.ast",

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
                 },
                 {
                     "command": "clangd.switchheadersource",
-                    "group": "navigation@5"
+                    "group": "0_navigation@5"
                 },
                 {
                     "command": "clangd.ast",

--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
                 },
                 {
                     "command": "clangd.switchheadersource",
+                    "when": "resourceLangId == c || resourceLangId == cpp || resourceLangId == cuda || resourceLangId == objective-c || resourceLangId == objective-cpp",
                     "group": "0_navigation@5"
                 },
                 {


### PR DESCRIPTION
Based on `activationEvents` in package.json, the plugin is only enabled for c/cpp/cuda/objc/obcpp, and all of those have header/source files (except maybe cuda?). I've confirmed with an objc .m/.h pair that this works correctly.

I also added a category for all commands and removed the clangd prefix from the title. This keeps the "clangd: " prefix on all commands in the command palette, but uses only the title in the context menu (which looks nicer).

![image](https://user-images.githubusercontent.com/43076169/142595859-a1f9d4ea-09d8-4dad-8825-1301e88ab48d.png)

![image](https://user-images.githubusercontent.com/43076169/142595910-f73ae3e8-3fc4-44e5-8ee8-c5106bb24547.png)
