### PR TITLE
export hover api

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,24 +337,24 @@
             ]
         },
         "colors": [
-          {
-            "id": "clangd.inlayHints.foreground",
-            "description": "Foreground color of inlay hints",
-            "defaults": {
-              "dark": "#A0A0A0F0",
-              "light": "#747474",
-              "highContrast": "#BEBEBE"
+            {
+                "id": "clangd.inlayHints.foreground",
+                "description": "Foreground color of inlay hints",
+                "defaults": {
+                    "dark": "#A0A0A0F0",
+                    "light": "#747474",
+                    "highContrast": "#BEBEBE"
+                }
+            },
+            {
+                "id": "clangd.inlayHints.background",
+                "description": "Background color of inlay hints",
+                "defaults": {
+                    "dark": "#11223300",
+                    "light": "#11223300",
+                    "highContrast": "#11223300"
+                }
             }
-          },
-          {
-            "id": "clangd.inlayHints.background",
-            "description": "Background color of inlay hints",
-            "defaults": {
-              "dark": "#11223300",
-              "light": "#11223300",
-              "highContrast": "#11223300"
-            }
-          }
         ]
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,18 @@
+import * as vscodelc from 'vscode-languageclient/node';
+
+type MarkupKind = 'PlainText' | 'Markdown';
+
+export interface MarkupContent {
+    kind: MarkupKind;
+    value: string;
+}
+
+export interface Hover {
+    contents: MarkupContent
+    range?: vscodelc.Range
+}
+
+// Support for exported apis
+export interface API {
+    hover(): Promise<Hover|null>
+}

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -12,6 +12,7 @@ import * as openConfig from './open-config';
 import * as semanticHighlighting from './semantic-highlighting';
 import * as switchSourceHeader from './switch-source-header';
 import * as typeHierarchy from './type-hierarchy';
+import { Hover } from './api';
 
 const clangdDocumentSelector = [
   {scheme: 'file', language: 'c'},
@@ -174,5 +175,22 @@ export class ClangdContext implements vscode.Disposable {
   dispose() {
     this.subscriptions.forEach((d) => { d.dispose(); });
     this.subscriptions = []
+  }
+
+  hover(): Promise<Hover|null> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return new Promise((_resolve, reject) => {
+        reject(null);
+      });
+    }
+    const position = editor.selection.active;
+    const uri = editor.document.uri;
+    return this.client.sendRequest<any>('textDocument/hover', {
+      position,
+      textDocument: {
+        uri: uri.toString(true),
+      },
+    });
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import {ClangdContext} from './clangd-context';
+import { API, Hover } from './api';
 
 /**
  *  This method is called when the extension is activated. The extension is
@@ -19,12 +20,12 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand('clangd.activate', async () => {}));
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
-        await clangdContext.dispose();
-        await clangdContext.activate(context.globalStoragePath, outputChannel,
+        clangdContext.dispose();
+        await clangdContext.activate(context.globalStorageUri.fsPath, outputChannel,
                                      context.workspaceState);
       }));
 
-  await clangdContext.activate(context.globalStoragePath, outputChannel,
+  await clangdContext.activate(context.globalStorageUri.fsPath, outputChannel,
                                context.workspaceState);
 
   const shouldCheck = vscode.workspace.getConfiguration('clangd').get(
@@ -59,4 +60,12 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     }, 5000);
   }
+
+  const api: API = {
+    hover(): Promise<Hover|null> {
+      return clangdContext.hover();
+    }
+  };
+
+  return api;
 }


### PR DESCRIPTION
I developed a plugin that required clangd's hover api, so i exported the hover api to allow more people to extend it.