### PR TITLE
Subscribe the registered inlyHints.toggle command.

### DIFF
--- a/src/inlay-hints.ts
+++ b/src/inlay-hints.ts
@@ -129,12 +129,13 @@ class InlayHintsFeature implements vscodelc.StaticFeature {
       // The command provides a quick way to toggle inlay hints (key-bindable).
       // FIXME: this is a core VSCode setting, ideally they provide the command.
       // We toggle it globally, language-specific is nicer but undiscoverable.
-      vscode.commands.registerCommand('clangd.inlayHints.toggle', () => {
-        const current = vscode.workspace.getConfiguration().get<boolean>(
-            enabledSetting, false);
-        vscode.workspace.getConfiguration().update(
-            enabledSetting, !current, vscode.ConfigurationTarget.Global);
-      });
+      this.context.subscriptions.push(
+          vscode.commands.registerCommand('clangd.inlayHints.toggle', () => {
+            const current = vscode.workspace.getConfiguration().get<boolean>(
+                enabledSetting, false);
+            vscode.workspace.getConfiguration().update(
+                enabledSetting, !current, vscode.ConfigurationTarget.Global);
+          }));
       vscode.workspace.onDidChangeConfiguration(e => {
         if (e.affectsConfiguration(enabledSetting))
           this.checkEnabled()


### PR DESCRIPTION
Otherwise it is not released -- we hit a "command 'clangd.inlayHints.toggle' already exists" error
when we run the "restart clangd" command.