### PR TITLE
Update clang-format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "vscode-clangd",
-            "version": "0.1.14",
+            "version": "0.1.15",
             "license": "MIT",
             "dependencies": {
                 "@clangd/install": "0.1.4",
@@ -18,7 +18,7 @@
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^6.0.40",
                 "@types/vscode": "1.56.*",
-                "clang-format": "1.4.0",
+                "clang-format": "1.6.0",
                 "esbuild": "^0.14.13",
                 "glob": "^7.1.4",
                 "mocha": "^9.2.0",
@@ -452,9 +452,9 @@
             "dev": true
         },
         "node_modules/clang-format": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.4.0.tgz",
-            "integrity": "sha512-NrdyUnHJOGvMa60vbWk7GJTvOdhibj3uK5C0FlwdNG4301OUvqEJTFce9I9x8qw2odBbIVrJ+9xbsFS3a4FbDA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.6.0.tgz",
+            "integrity": "sha512-W3/L7fWkA8DoLkz9UGjrRnNi+J5a5TuS2HDLqk6WsicpOzb66MBu4eY/EcXhicHriVnAXWQVyk5/VeHWY6w4ow==",
             "dev": true,
             "dependencies": {
                 "async": "^1.5.2",
@@ -2837,9 +2837,9 @@
             "dev": true
         },
         "clang-format": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.4.0.tgz",
-            "integrity": "sha512-NrdyUnHJOGvMa60vbWk7GJTvOdhibj3uK5C0FlwdNG4301OUvqEJTFce9I9x8qw2odBbIVrJ+9xbsFS3a4FbDA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.6.0.tgz",
+            "integrity": "sha512-W3/L7fWkA8DoLkz9UGjrRnNi+J5a5TuS2HDLqk6WsicpOzb66MBu4eY/EcXhicHriVnAXWQVyk5/VeHWY6w4ow==",
             "dev": true,
             "requires": {
                 "async": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^6.0.40",
         "@types/vscode": "1.56.*",
-        "clang-format": "1.4.0",
+        "clang-format": "1.6.0",
         "esbuild": "^0.14.13",
         "glob": "^7.1.4",
         "mocha": "^9.2.0",


### PR DESCRIPTION
I'm hoping this fixes some ignored clang format options such as the ability to have initializer list items on [separate lines](https://stackoverflow.com/questions/56811537/clang-format-how-to-keep-each-element-of-constructors-initializer-list-on-a-se) though tbh the clang-format releases aren't well documented so it's hard to see