### PR TITLE
Fix the broken debugging workflow.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,8 +21,8 @@
         "reveal": "silent",
     },
 
-    // Run custom "compile" script as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
+    // Run custom "ts-compile" script as defined in package.json
+    "args": ["run", "ts-compile", "--loglevel", "silent"],
 
     // tsc compiler is kept alive and runs in the background.
     "isBackground": true,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "esbuild": "esbuild ./src/extension.ts --bundle --outfile=out/bundle.js --external:vscode --format=cjs --platform=node",
         "vscode:prepublish": "npm run esbuild -- --minify",
         "compile": "npm run esbuild -- --sourcemap --watch",
+        "ts-compile": "tsc -watch -p ./",
         "format": "clang-format -i --glob=\"{src,test}/*.ts\"",
         "test": "tsc -p ./ && node ./out/test/index.js",
         "package": "vsce package --baseImagesUrl https://raw.githubusercontent.com/clangd/vscode-clangd/master/",


### PR DESCRIPTION
The `F5`-debugging workflow has been broken since #287, this patch brings it back.