### PR TITLE
Disable commit-characters for all code completion.

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -115,6 +115,12 @@ export class ClangdContext implements vscode.Disposable {
                 new vscode.Range((item.range as vscode.Range).start, position))
             if (prefix)
             item.filterText = prefix + '_' + item.filterText;
+            // Workaround for https://github.com/clangd/vscode-clangd/issues/357
+            // clangd's used of commit-characters was well-intentioned, but
+            // overall UX is poor. Due to vscode-languageclient bugs, we didn't
+            // notice until the behavior was in several releases, so we need
+            // to override it on the client.
+            item.commitCharacters = [];
             return item;
           })
           return new vscode.CompletionList(items, /*isIncomplete=*/ true);


### PR DESCRIPTION
The use of commit-characters in clangd had good intentions, but it has
terrible UX in practice in VSCode, as documented on the linked bug.

We didn't notice this until it was far too late: the commit characters
were added in clangd 12, but bugs in vscode-languageclient prevented
them from being noticed until languageclient-8.
(https://github.com/microsoft/vscode-languageserver-node/issues/673)

At this point we can't go back and change the server behavior so we need
to override it on the client.

Fixes https://github.com/clangd/vscode-clangd/issues/357