### PR TITLE
[TypeHierarchy] Properly handle standard protocol

### DIFF
--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -101,8 +101,10 @@ class TypeHierarchyTreeItem extends vscode.TreeItem {
 class TypeHierarchyFeature implements vscodelc.StaticFeature {
   private serverSupportsTypeHierarchy = false;
   private state!: vscodelc.State;
+  private context: ClangdContext;
 
   constructor(context: ClangdContext) {
+    this.context = context;
     new TypeHierarchyProvider(context);
     context.subscriptions.push(context.client.onDidChangeState(stateChange => {
       this.state = stateChange.newState;
@@ -116,10 +118,21 @@ class TypeHierarchyFeature implements vscodelc.StaticFeature {
   initialize(capabilities: vscodelc.ServerCapabilities,
              documentSelector: vscodelc.DocumentSelector|undefined) {
     const serverCapabilities: vscodelc.ServerCapabilities&
-        {typeHierarchyProvider?: any} = capabilities;
-    if (serverCapabilities.typeHierarchyProvider) {
+        {standardTypeHierarchyProvider?: any} = capabilities;
+    // Unfortunately clangd used the same capability name for its pre-standard
+    // protocol as the standard ended up using. We need to prevent
+    // vscode-languageclient from trying to query clangd versions that speak the
+    // incompatible protocol.
+    if (serverCapabilities.typeHierarchyProvider &&
+        !serverCapabilities.standardTypeHierarchyProvider) {
+      // Disable mis-guided support for standard type-hierarchy feature.
+      this.context.client.getFeature('textDocument/prepareTypeHierarchy')
+          .dispose();
       this.serverSupportsTypeHierarchy = true;
       this.recomputeEnableTypeHierarchy();
+    } else {
+      // Either clangd has support for the standard protocol, or no
+      // implementation at all. In either case, don't turn on the extension.
     }
   }
   getState(): vscodelc.FeatureState { return {kind: 'static'}; }


### PR DESCRIPTION
Due to a conflict in advertising capability for clangd's type-hierarchy
extension and standard protocol we're going to have both of them available
in newer vscode clients (while clangd's prior to 15 release won't be able to
provide support for the standard protocol).

This patch ensures we're only showing one version of type-hierarchy, preferring
the standard one when clangd supports it, and disabling the standard when clangd
doesn't have support.
