### PR TITLE
Remove redundant `TreeDataProvider` registrations

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -47,7 +47,6 @@ class ASTFeature implements vscodelc.StaticFeature {
             // @ts-ignore
             tree.reveal(null);
         }),
-        vscode.window.registerTreeDataProvider('clangd.ast', adapter),
         // Create the "Show AST" command for the context menu.
         // It's only shown if the feature is dynamicaly available (package.json)
         vscode.commands.registerTextEditorCommand(

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -169,9 +169,6 @@ class TypeHierarchyProvider implements
   constructor(context: ClangdContext) {
     this.client = context.client;
 
-    context.subscriptions.push(vscode.window.registerTreeDataProvider(
-        'clangd.typeHierarchyView', this));
-
     context.subscriptions.push(vscode.commands.registerTextEditorCommand(
         'clangd.typeHierarchy', this.reveal, this));
     context.subscriptions.push(vscode.commands.registerCommand(


### PR DESCRIPTION
In the type hierarchy tree and AST tree code, both `vscode.window.registerTreeDataProvider` and `vscode.window.createTreeView` are called with the same ID, `clangd.typeHierarchyView` and `clangd.ast`, respectively. These calls are redundant, as `registerTreeDataProvider` just delegates to `createTreeView`:

https://github.com/microsoft/vscode/blob/6f7820c454195fd9d9749022f911a08a004f34bd/src/vs/workbench/api/common/extHostTreeViews.ts#L81-L84

VSCode handles the redundancy gracefully, but when the plugin is run in Theia, errors are logged about both views:

![image](https://user-images.githubusercontent.com/62660806/195462049-2d63ae5c-3f87-4be3-ae8d-6bbe55cca833.png)

![image](https://user-images.githubusercontent.com/62660806/195462098-14eb21e4-d783-43ae-8f57-5ebf9d969e1f.png)
