### PR TITLE
Enable clangd on HLSL sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "onLanguage:cuda-cpp",
         "onLanguage:objective-c",
         "onLanguage:objective-cpp",
+        "onLanguage:hlsl",
         "onCommand:clangd.activate",
         "onCommand:clangd.install",
         "onCommand:clangd.update"

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -18,6 +18,7 @@ export const clangdDocumentSelector = [
   {scheme: 'file', language: 'cuda-cpp'},
   {scheme: 'file', language: 'objective-c'},
   {scheme: 'file', language: 'objective-cpp'},
+  {scheme: 'file', language: 'hlsl'},
 ];
 
 export function isClangdDocument(document: vscode.TextDocument) {


### PR DESCRIPTION
Clang is gaining support for HLSL. This change enables using clangd for the language server for vscode.

I'm unsure if there is a good way to gate this support on a specific version of clang, but when used with clang-15 it produces an error at the beginning of the file noting that compilation failed. It doesn't do anything too terrible if clang can't handle HLSL, so it might be safe to enable everywhere as-is.