### PR TITLE
Remove custom secure configuration items and rely on workspace trust from vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,13 @@
         "url": "https://github.com/clangd/vscode-clangd.git"
     },
     "qna": "marketplace",
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": "limited",
+            "description": "In restricted mode clangd.path and clangd.arguments are not respected.",
+            "restrictedConfigurations": ["clangd.path", "clangd.arguments"]
+        }
+    },
     "contributes": {
         "languages": [
             {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -59,17 +59,15 @@ export class ClangdContext implements vscode.Disposable {
   subscriptions: vscode.Disposable[] = [];
   client!: ClangdLanguageClient;
 
-  async activate(globalStoragePath: string, outputChannel: vscode.OutputChannel,
-                 workspaceState: vscode.Memento) {
-    const clangdPath =
-        await install.activate(this, globalStoragePath, workspaceState);
+  async activate(globalStoragePath: string,
+                 outputChannel: vscode.OutputChannel) {
+    const clangdPath = await install.activate(this, globalStoragePath);
     if (!clangdPath)
       return;
 
     const clangd: vscodelc.Executable = {
       command: clangdPath,
-      args:
-          await config.getSecureOrPrompt<string[]>('arguments', workspaceState),
+      args: await config.get<string[]>('arguments'),
       options: {cwd: vscode.workspace.rootPath || process.cwd()}
     };
     const traceFile = config.get<string>('trace');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,12 +20,10 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
         await clangdContext.dispose();
-        await clangdContext.activate(context.globalStoragePath, outputChannel,
-                                     context.workspaceState);
+        await clangdContext.activate(context.globalStoragePath, outputChannel);
       }));
 
-  await clangdContext.activate(context.globalStoragePath, outputChannel,
-                               context.workspaceState);
+  await clangdContext.activate(context.globalStoragePath, outputChannel);
 
   const shouldCheck = vscode.workspace.getConfiguration('clangd').get(
       'detectExtensionConflicts');

--- a/src/install.ts
+++ b/src/install.ts
@@ -11,12 +11,11 @@ import * as config from './config';
 
 // Returns the clangd path to be used, or null if clangd is not installed.
 export async function activate(
-    context: ClangdContext, globalStoragePath: string,
-    workspaceState: vscode.Memento): Promise<string|null> {
+    context: ClangdContext, globalStoragePath: string): Promise<string|null> {
   // If the workspace overrides clangd.path, give the user a chance to bless it.
-  await config.getSecureOrPrompt<string>('path', workspaceState);
+  await config.get<string>('path');
 
-  const ui = new UI(context, globalStoragePath, workspaceState);
+  const ui = new UI(context, globalStoragePath);
   context.subscriptions.push(vscode.commands.registerCommand(
       'clangd.install', async () => common.installLatest(ui)));
   context.subscriptions.push(vscode.commands.registerCommand(
@@ -26,8 +25,8 @@ export async function activate(
 }
 
 class UI {
-  constructor(private context: ClangdContext, private globalStoragePath: string,
-              private workspaceState: vscode.Memento) {}
+  constructor(private context: ClangdContext,
+              private globalStoragePath: string) {}
 
   get storagePath(): string { return this.globalStoragePath; }
   async choose(prompt: string, options: string[]): Promise<string|undefined> {
@@ -125,7 +124,7 @@ class UI {
   }
 
   get clangdPath(): string {
-    let p = config.getSecure<string>('path', this.workspaceState)!;
+    let p = config.get<string>('path')!;
     // Backwards compatibility: if it's a relative path with a slash, interpret
     // relative to project root.
     if (!path.isAbsolute(p) && p.includes(path.sep) &&


### PR DESCRIPTION
See discussion in:
- https://github.com/clangd/vscode-clangd/issues/318
- https://github.com/clangd/clangd/discussions/1488

This PR removes the custom logic and sets the configuration items `clangd.path` and `clangd.arguments` to limited in restricted mode.