### PR TITLE
Avoid undefined object access in ClangdContext.dispose()

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -175,7 +175,8 @@ export class ClangdContext implements vscode.Disposable {
 
   dispose() {
     this.subscriptions.forEach((d) => { d.dispose(); });
-    this.client.stop();
+    if (this.client)
+      this.client.stop();
     this.subscriptions = []
   }
 }


### PR DESCRIPTION
this.client may not have been set if activate() failed for some reason (e.g. the clangd executable could not be found and the user opted not to install it via auto-install)

Partially fixes https://github.com/clangd/vscode-clangd/issues/406