### PR TITLE
Add hotkey to open cppreference documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,6 +279,11 @@
                 "category": "clangd",
                 "title": "Toggle inlay hints",
                 "enablement": "clangd.inlayHints.supported"
+            },
+            {
+                "command": "clangd.openDocumentation",
+                "category": "clangd",
+                "title": "Open CppReference documentation for symbol under cursor"
             }
         ],
         "keybindings": [
@@ -291,6 +296,11 @@
             {
                 "command": "clangd.typeHierarchy",
                 "key": "Shift+Alt+t",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "clangd.openDocumentation",
+                "key": "Shift+f1",
                 "when": "editorTextFocus"
             }
         ],

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -4,6 +4,7 @@ import * as vscodelc from 'vscode-languageclient/node';
 import * as ast from './ast';
 import * as config from './config';
 import * as configFileWatcher from './config-file-watcher';
+import * as docCppref from './doc-cppref';
 import * as fileStatus from './file-status';
 import * as inactiveRegions from './inactive-regions';
 import * as inlayHints from './inlay-hints';
@@ -168,6 +169,7 @@ export class ClangdContext implements vscode.Disposable {
     fileStatus.activate(this);
     switchSourceHeader.activate(this);
     configFileWatcher.activate(this);
+    docCppref.activate(this);
   }
 
   get visibleClangdEditors(): vscode.TextEditor[] {

--- a/src/doc-cppref.ts
+++ b/src/doc-cppref.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+import * as vscodelc from 'vscode-languageclient/node';
+
+import {ClangdContext} from './clangd-context';
+
+export function activate(context: ClangdContext) {
+  const feature = new DocCppReferenceFeature(context);
+  context.client.registerFeature(feature);
+}
+
+namespace protocol {
+
+export interface SymbolInfo {
+  name: string;
+  containerName: string;
+  usr: string;
+  id?: string;
+}
+
+export interface SymbolInfoParams {
+  textDocument: vscodelc.TextDocumentIdentifier;
+  position: vscodelc.Position;
+}
+
+export namespace SymbolInfoRequest {
+export const type =
+    new vscodelc.RequestType<SymbolInfoParams, SymbolInfo[], void>(
+        'textDocument/symbolInfo');
+}
+
+} // namespace protocol
+
+class DocCppReferenceFeature implements vscodelc.StaticFeature {
+  private url = 'https://duckduckgo.com/?q=!ducky+site:cppreference.com';
+  private commandRegistered = false;
+
+  constructor(private readonly context: ClangdContext) {}
+
+  fillClientCapabilities(_capabilities: vscodelc.ClientCapabilities) {}
+  fillInitializeParams(_params: vscodelc.InitializeParams) {}
+
+  async getSymbolsUnderCursor(): Promise<Array<string>> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor)
+      return [];
+
+    const document = editor.document;
+    const position = editor.selection.active;
+    const request: protocol.SymbolInfoParams = {
+      textDocument: {uri: document.uri.toString()},
+      position: position,
+    };
+
+    const reply = await this.context.client.sendRequest(
+        protocol.SymbolInfoRequest.type, request);
+
+    let result: Array<string> = [];
+    reply.forEach(symbol => {
+      if (symbol.name === null || symbol.name === undefined)
+        return;
+
+      if (symbol.containerName === null || symbol.containerName === undefined) {
+        result.push(symbol.name);
+        return;
+      }
+
+      const needComas =
+          !symbol.containerName.endsWith('::') && !symbol.name.startsWith('::');
+      result.push(symbol.containerName + (needComas ? '::' : '') + symbol.name);
+    });
+
+    return result;
+  }
+
+  async openDocumentation() {
+    const symbols = await this.getSymbolsUnderCursor();
+    symbols.forEach(symbol => {
+      if (!symbol.startsWith('std::'))
+        return;
+
+      vscode.commands.executeCommand('vscode.open',
+                                     vscode.Uri.parse(this.url + '+' + symbol));
+    });
+  }
+
+  initialize(capabilities: vscodelc.ServerCapabilities,
+             _documentSelector: vscodelc.DocumentSelector|undefined) {
+    if (this.commandRegistered)
+      return;
+    this.commandRegistered = true;
+
+    this.context.subscriptions.push(vscode.commands.registerCommand(
+        'clangd.openDocumentation', this.openDocumentation, this));
+  }
+  getState(): vscodelc.FeatureState { return {kind: 'static'}; }
+  dispose() {}
+}


### PR DESCRIPTION
This PR add hotkey `Shift+f1` to open documentation on cppreference.com, like in CLion.

I added this feature in clangd extension, because VSCode do not provide API to get symbol info from LSP, and standalone doc extensions can't get symbol scope.

Example:
```cpp
std::string foo;
auto bar = foo.da^ta();
```
For this code, standalone extensions opens doc for `std::data`. With this PR clangd open doc for `std::string::data`