### PR TITLE
Add integration with cmake-tools extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Version 0.1.27: March 16, 2023
+## Version 0.1.27: March 16, 2024
 
 * Trigger signature help when accepting code completions, where appropriate [#390](https://github.com/clangd/vscode-clangd/issues/390)
 * Gracefully handle `clangd.restart`` being invoked when the extension hasn't been activated yet [#502](https://github.com/clangd/vscode-clangd/issues/502)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Next (not yet released)
+## Version 0.1.25: August 15, 2023
 
 * Combine inactive region style with client-side (textmate) token colors [#193](https://github.com/clangd/vscode-clangd/pull/193).
   Requires clangd 17 or later.
@@ -9,6 +9,7 @@
   * An alternative inactive region style of a background highlight can be enabled with
     `clangd.inactiveRegions.useBackgroundHighlight=true`. The highlight color can be
     customized with `clangd.inactiveRegions.background` in `workbench.colorCustomizations`.
+* The variable substitution `${userHome}` is now supported in clangd configuration setting values [#486](https://github.com/clangd/vscode-clangd/pull/486)
 
 ## Version 0.1.24: April 21, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 0.1.26: December 20, 2023
+
+* Bump @clangd/install dependency to 0.1.17. This works around a bug in a
+  dependent library affecting node versions 18.16 and later that can cause
+  the downloaded clangd executable to be corrupt after unzipping.
+
 ## Version 0.1.25: August 15, 2023
 
 * Combine inactive region style with client-side (textmate) token colors [#193](https://github.com/clangd/vscode-clangd/pull/193).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 
+## Version 0.1.28: March 20, 2024
+
+* Fix a regression in the behaviour of `clangd.restart` introduced in 0.1.27 [#599](https://github.com/clangd/vscode-clangd/issues/599)
+
 ## Version 0.1.27: March 16, 2024
 
 * Trigger signature help when accepting code completions, where appropriate [#390](https://github.com/clangd/vscode-clangd/issues/390)
-* Gracefully handle `clangd.restart`` being invoked when the extension hasn't been activated yet [#502](https://github.com/clangd/vscode-clangd/issues/502)
+* Gracefully handle `clangd.restart` being invoked when the extension hasn't been activated yet [#502](https://github.com/clangd/vscode-clangd/issues/502)
 * Add an option to disable code completion [#588](https://github.com/clangd/vscode-clangd/issues/588)
 
 ## Version 0.1.26: December 20, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 0.1.27: March 16, 2023
+
+* Trigger signature help when accepting code completions, where appropriate [#390](https://github.com/clangd/vscode-clangd/issues/390)
+* Gracefully handle `clangd.restart`` being invoked when the extension hasn't been activated yet [#502](https://github.com/clangd/vscode-clangd/issues/502)
+* Add an option to disable code completion [#588](https://github.com/clangd/vscode-clangd/issues/588)
+
 ## Version 0.1.26: December 20, 2023
 
 * Bump @clangd/install dependency to 0.1.17. This works around a bug in a

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "sinon": "^15.2.0",
                 "typescript": "^4.5.5",
                 "vsce": "^2.7.0",
+                "vscode-cmake-tools": "^1.0.0",
                 "vscode-test": "^1.3.0"
             },
             "engines": {
@@ -3041,6 +3042,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/vscode-cmake-tools": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-cmake-tools/-/vscode-cmake-tools-1.0.0.tgz",
+            "integrity": "sha512-oZO+Ulo+OGaFuGQaPlNh+qDUWth0kmyz0d45Ws6KmqLGf1Q9gCOBct6jz7mAtzR/IqrCe/VV3O/CUmHfXpIZEA==",
+            "dev": true,
+            "engines": {
+                "vscode": "^1.63.0"
+            }
+        },
         "node_modules/vscode-jsonrpc": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
@@ -5538,6 +5548,12 @@
                     }
                 }
             }
+        },
+        "vscode-cmake-tools": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-cmake-tools/-/vscode-cmake-tools-1.0.0.tgz",
+            "integrity": "sha512-oZO+Ulo+OGaFuGQaPlNh+qDUWth0kmyz0d45Ws6KmqLGf1Q9gCOBct6jz7mAtzR/IqrCe/VV3O/CUmHfXpIZEA==",
+            "dev": true
         },
         "vscode-jsonrpc": {
             "version": "8.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-clangd",
-    "version": "0.1.24",
+    "version": "0.1.25",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-clangd",
-            "version": "0.1.24",
+            "version": "0.1.25",
             "license": "MIT",
             "dependencies": {
                 "@clangd/install": "0.1.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-clangd",
-    "version": "0.1.25",
+    "version": "0.1.27",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-clangd",
-            "version": "0.1.25",
+            "version": "0.1.27",
             "license": "MIT",
             "dependencies": {
                 "@clangd/install": "0.1.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-clangd",
-    "version": "0.1.27",
+    "version": "0.1.28",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-clangd",
-            "version": "0.1.27",
+            "version": "0.1.28",
             "license": "MIT",
             "dependencies": {
                 "@clangd/install": "0.1.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.25",
             "license": "MIT",
             "dependencies": {
-                "@clangd/install": "0.1.16",
+                "@clangd/install": "0.1.17",
                 "abort-controller": "^3.0.0",
                 "vscode-languageclient": "8.0.2"
             },
@@ -35,16 +35,16 @@
             }
         },
         "node_modules/@clangd/install": {
-            "version": "0.1.16",
-            "resolved": "https://registry.npmjs.org/@clangd/install/-/install-0.1.16.tgz",
-            "integrity": "sha512-RPTDLafxSZHJa6cQk0fWAmEXZgGDI3PYDZgvtkIvwNfprRoxhurbaVpAu0R6LuBN/7n3LHayHopzJlb/7fon5A==",
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/@clangd/install/-/install-0.1.17.tgz",
+            "integrity": "sha512-wXH+5pao1/D4svPHJ7Hzp8BbAlLn/w/ZH9bAGtWoIqtJ5kCAoE3C8m/d6TzOdsbRSxQEEb7dplIFdbSwJHeAeg==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
+                "adm-zip": "^0.5.10",
                 "node-fetch": "^2.6.0",
                 "readdirp": "^3.4.0",
                 "rimraf": "^3.0.2",
                 "semver": "^7.3.2",
-                "unzipper": "^0.10.11",
                 "which": "^2.0.2"
             }
         },
@@ -165,6 +165,14 @@
             },
             "engines": {
                 "node": ">=6.5"
+            }
+        },
+        "node_modules/adm-zip": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+            "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+            "engines": {
+                "node": ">=6.0"
             }
         },
         "node_modules/agent-base": {
@@ -292,6 +300,7 @@
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -300,6 +309,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -345,7 +355,8 @@
         "node_modules/bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
@@ -417,6 +428,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
             "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -425,6 +437,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
             "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.2.0"
             }
@@ -458,6 +471,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
             },
@@ -692,7 +706,8 @@
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "node_modules/css-select": {
             "version": "5.1.0",
@@ -864,6 +879,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
@@ -1383,6 +1399,7 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -1397,6 +1414,7 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -1489,7 +1507,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "node_modules/growl": {
             "version": "1.10.5",
@@ -1748,7 +1767,8 @@
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -1805,7 +1825,8 @@
         "node_modules/listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -1924,12 +1945,14 @@
         "node_modules/minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
         },
         "node_modules/mkdirp": {
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -2365,7 +2388,8 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "node_modules/pump": {
             "version": "3.0.0",
@@ -2441,6 +2465,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2454,7 +2479,8 @@
         "node_modules/readable-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -2565,7 +2591,8 @@
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
         },
         "node_modules/side-channel": {
             "version": "1.0.4",
@@ -2675,6 +2702,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -2682,7 +2710,8 @@
         "node_modules/string_decoder/node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/string-width": {
             "version": "1.0.2",
@@ -2824,6 +2853,7 @@
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -2904,6 +2934,7 @@
             "version": "0.10.11",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
             "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
             "dependencies": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -2926,7 +2957,8 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "node_modules/vsce": {
             "version": "2.8.0",
@@ -3367,16 +3399,16 @@
     },
     "dependencies": {
         "@clangd/install": {
-            "version": "0.1.16",
-            "resolved": "https://registry.npmjs.org/@clangd/install/-/install-0.1.16.tgz",
-            "integrity": "sha512-RPTDLafxSZHJa6cQk0fWAmEXZgGDI3PYDZgvtkIvwNfprRoxhurbaVpAu0R6LuBN/7n3LHayHopzJlb/7fon5A==",
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/@clangd/install/-/install-0.1.17.tgz",
+            "integrity": "sha512-wXH+5pao1/D4svPHJ7Hzp8BbAlLn/w/ZH9bAGtWoIqtJ5kCAoE3C8m/d6TzOdsbRSxQEEb7dplIFdbSwJHeAeg==",
             "requires": {
                 "abort-controller": "^3.0.0",
+                "adm-zip": "^0.5.10",
                 "node-fetch": "^2.6.0",
                 "readdirp": "^3.4.0",
                 "rimraf": "^3.0.2",
                 "semver": "^7.3.2",
-                "unzipper": "^0.10.11",
                 "which": "^2.0.2"
             }
         },
@@ -3495,6 +3527,11 @@
                 "event-target-shim": "^5.0.0"
             }
         },
+        "adm-zip": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+            "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
+        },
         "agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -3587,12 +3624,14 @@
         "big-integer": {
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true
         },
         "binary": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
             "requires": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -3631,7 +3670,8 @@
         "bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
         },
         "boolbase": {
             "version": "1.0.0",
@@ -3682,12 +3722,14 @@
         "buffer-indexof-polyfill": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true
         },
         "buffers": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true
         },
         "call-bind": {
             "version": "1.0.2",
@@ -3709,6 +3751,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
             "requires": {
                 "traverse": ">=0.3.0 <0.4"
             }
@@ -3889,7 +3932,8 @@
         "core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "css-select": {
             "version": "5.1.0",
@@ -4007,6 +4051,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.2"
             }
@@ -4285,6 +4330,7 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -4296,6 +4342,7 @@
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
                     "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -4372,7 +4419,8 @@
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "growl": {
             "version": "1.10.5",
@@ -4553,7 +4601,8 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -4603,7 +4652,8 @@
         "listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
         },
         "locate-path": {
             "version": "6.0.0",
@@ -4688,12 +4738,14 @@
         "minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+            "dev": true
         },
         "mkdirp": {
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "requires": {
                 "minimist": "^1.2.6"
             }
@@ -5033,7 +5085,8 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "pump": {
             "version": "3.0.0",
@@ -5096,6 +5149,7 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -5109,7 +5163,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
@@ -5184,7 +5239,8 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
         },
         "side-channel": {
             "version": "1.0.4",
@@ -5255,6 +5311,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             },
@@ -5262,7 +5319,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
@@ -5371,7 +5429,8 @@
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+            "dev": true
         },
         "tslib": {
             "version": "2.4.0",
@@ -5433,6 +5492,7 @@
             "version": "0.10.11",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
             "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+            "dev": true,
             "requires": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -5455,7 +5515,8 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "vsce": {
             "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "git-clang-format": "git-clang-format --extensions=ts"
     },
     "dependencies": {
-        "@clangd/install": "0.1.16",
+        "@clangd/install": "0.1.17",
         "abort-controller": "^3.0.0",
         "vscode-languageclient": "8.0.2"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-clangd",
     "displayName": "clangd",
     "description": "C/C++ completion, navigation, and insights",
-    "version": "0.1.25",
+    "version": "0.1.26",
     "publisher": "llvm-vs-code-extensions",
     "license": "MIT",
     "homepage": "https://clangd.llvm.org/",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-clangd",
     "displayName": "clangd",
     "description": "C/C++ completion, navigation, and insights",
-    "version": "0.1.27",
+    "version": "0.1.28",
     "publisher": "llvm-vs-code-extensions",
     "license": "MIT",
     "homepage": "https://clangd.llvm.org/",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-clangd",
     "displayName": "clangd",
     "description": "C/C++ completion, navigation, and insights",
-    "version": "0.1.24",
+    "version": "0.1.25",
     "publisher": "llvm-vs-code-extensions",
     "license": "MIT",
     "homepage": "https://clangd.llvm.org/",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
         "sinon": "^15.2.0",
         "typescript": "^4.5.5",
         "vsce": "^2.7.0",
-        "vscode-test": "^1.3.0"
+        "vscode-test": "^1.3.0",
+        "vscode-cmake-tools": "^1.0.0"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,11 @@
                     "type": "number",
                     "default": 0.55,
                     "description": "Opacity of inactive regions (used only if clangd.inactiveRegions.useBackgroundHighlight=false)"
+                },
+                "clangd.enableCodeCompletion": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Enable code completion provided by the language server"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-clangd",
     "displayName": "clangd",
     "description": "C/C++ completion, navigation, and insights",
-    "version": "0.1.26",
+    "version": "0.1.27",
     "publisher": "llvm-vs-code-extensions",
     "license": "MIT",
     "homepage": "https://clangd.llvm.org/",

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -112,6 +112,8 @@ export class ClangdContext implements vscode.Disposable {
       middleware: {
         provideCompletionItem: async (document, position, context, token,
                                       next) => {
+          if (!config.get<boolean>('enableCodeCompletion'))
+            return new vscode.CompletionList([], /*isIncomplete=*/ false);
           let list = await next(document, position, context, token);
           if (!config.get<boolean>('serverCompletionRanking'))
             return list;

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -196,6 +196,10 @@ export class ClangdContext implements vscode.Disposable {
         (e) => isClangdDocument(e.document));
   }
 
+  clientIsReady() {
+    return this.client && this.client.state == vscodelc.State.Running;
+  }
+
   dispose() {
     this.subscriptions.forEach((d) => { d.dispose(); });
     if (this.client)

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
 import * as ast from './ast';
+import * as cmakeTools from './cmake-tools';
 import * as config from './config';
 import * as configFileWatcher from './config-file-watcher';
 import * as fileStatus from './file-status';
@@ -168,6 +169,7 @@ export class ClangdContext implements vscode.Disposable {
     fileStatus.activate(this);
     switchSourceHeader.activate(this);
     configFileWatcher.activate(this);
+    cmakeTools.activate(this);
   }
 
   get visibleClangdEditors(): vscode.TextEditor[] {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -67,9 +67,14 @@ export class ClangdContext implements vscode.Disposable {
     if (!clangdPath)
       return;
 
+    let args = await config.get<string[]>('arguments');
+    if (cmakeTools.clang_resource_dir !== undefined) {
+      args = [...args, `--resource-dir=${cmakeTools.clang_resource_dir}`];
+    }
+
     const clangd: vscodelc.Executable = {
       command: clangdPath,
-      args: await config.get<string[]>('arguments'),
+      args: args,
       options: {cwd: vscode.workspace.rootPath || process.cwd()}
     };
     const traceFile = config.get<string>('trace');

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -127,6 +127,20 @@ export class ClangdContext implements vscode.Disposable {
             // notice until the behavior was in several releases, so we need
             // to override it on the client.
             item.commitCharacters = [];
+            // VSCode won't automatically trigger signature help when entering
+            // a placeholder, e.g. if the completion inserted brackets and
+            // placed the cursor inside them.
+            // https://github.com/microsoft/vscode/issues/164310
+            // They say a plugin should trigger this, but LSP has no mechanism.
+            // https://github.com/microsoft/language-server-protocol/issues/274
+            // (This workaround is incomplete, and only helps the first param).
+            if (item.insertText instanceof vscode.SnippetString &&
+                !item.command &&
+                item.insertText.value.match(/[([{<,] ?\$\{?[01]\D/))
+              item.command = {
+                title: 'Signature help',
+                command: 'editor.action.triggerParameterHints'
+              };
             return item;
           })
           return new vscode.CompletionList(items, /*isIncomplete=*/ true);

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -198,8 +198,8 @@ export class ClangdContext implements vscode.Disposable {
         (e) => isClangdDocument(e.document));
   }
 
-  clientIsReady() {
-    return this.client && this.client.state == vscodelc.State.Running;
+  clientIsStarting() {
+    return this.client && this.client.state == vscodelc.State.Starting;
   }
 
   dispose() {

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1,0 +1,197 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as api from 'vscode-cmake-tools';
+import * as vscodelc from 'vscode-languageclient/node';
+
+import {ClangdContext} from './clangd-context';
+
+export function activate(context: ClangdContext) {
+  const feature = new CMakeToolsFeature(context);
+  context.client.registerFeature(feature);
+}
+
+namespace protocol {
+
+export interface DidChangeConfigurationClientCapabilities {
+  dynamicRegistration?: boolean;
+}
+
+export interface ClangdCompileCommand {
+  // Directory
+  workingDirectory: string;
+  // Command line
+  compilationCommand: string[];
+}
+
+export interface ConfigurationSettings {
+  // File -> ClangdCompileCommand
+  compilationDatabaseChanges: Object;
+}
+
+export interface DidChangeConfigurationParams {
+  settings: ConfigurationSettings;
+}
+
+export namespace DidChangeConfigurationRequest {
+export const type = new vscodelc.NotificationType<DidChangeConfigurationParams>(
+    'workspace/didChangeConfiguration');
+}
+
+} // namespace protocol
+
+class CMakeToolsFeature implements vscodelc.StaticFeature {
+  private projectChange: vscode.Disposable = {dispose() {}};
+  private codeModelChange: vscode.Disposable|undefined;
+  private cmakeTools: api.CMakeToolsApi|undefined;
+  private project: api.Project|undefined;
+  private codeModel: Map<string, protocol.ClangdCompileCommand>|undefined;
+
+  constructor(private readonly context: ClangdContext) {
+    let cmakeTools = api.getCMakeToolsApi(api.Version.v1);
+    if (cmakeTools === undefined)
+      return;
+
+    cmakeTools.then(api => {
+      this.cmakeTools = api;
+      if (this.cmakeTools === undefined)
+        return;
+
+      this.projectChange = this.cmakeTools.onActiveProjectChanged(
+          this.onActiveProjectChanged, this);
+      if (vscode.workspace.workspaceFolders !== undefined) {
+        // FIXME: clangd not supported multi-workspace projects
+        const projectUri = vscode.workspace.workspaceFolders[0].uri;
+        this.onActiveProjectChanged(projectUri);
+      }
+    });
+  }
+
+  fillClientCapabilities(_capabilities: vscodelc.ClientCapabilities) {}
+  fillInitializeParams(_params: vscodelc.InitializeParams) {}
+
+  initialize(capabilities: vscodelc.ServerCapabilities,
+             _documentSelector: vscodelc.DocumentSelector|undefined) {}
+  getState(): vscodelc.FeatureState { return {kind: 'static'}; }
+  dispose() {
+    if (this.codeModelChange !== undefined)
+      this.codeModelChange.dispose();
+    this.projectChange.dispose();
+  }
+
+  async onActiveProjectChanged(path: vscode.Uri|undefined) {
+    if (this.codeModelChange !== undefined) {
+      this.codeModelChange.dispose();
+      this.codeModelChange = undefined;
+    }
+
+    if (path === undefined)
+      return;
+
+    this.cmakeTools?.getProject(path).then(project => {
+      this.project = project;
+      this.codeModelChange =
+          this.project?.onCodeModelChanged(this.onCodeModelChanged, this);
+      this.onCodeModelChanged();
+    });
+  }
+
+  async onCodeModelChanged() {
+    const content = this.project?.codeModel;
+    if (content === undefined)
+      return;
+
+    if (content.toolchains === undefined)
+      return;
+
+    const request: protocol.DidChangeConfigurationParams = {
+      settings: {compilationDatabaseChanges: {}}
+    };
+
+    let codeModelChanges: Map<string, protocol.ClangdCompileCommand> =
+        new Map();
+    content.configurations.forEach(configuration => {
+      configuration.projects.forEach(project => {
+        let sourceDirectory = project.sourceDirectory;
+        project.targets.forEach(target => {
+          if (target.sourceDirectory !== undefined)
+            sourceDirectory = target.sourceDirectory;
+          let commandLine: string[] = [];
+          if (target.sysroot !== undefined)
+            commandLine.push(`--sysroot=${target.sysroot}`);
+          target.fileGroups?.forEach(fileGroup => {
+            if (fileGroup.language === undefined)
+              return;
+
+            const compiler = content.toolchains?.get(fileGroup.language);
+            if (compiler === undefined)
+              return;
+
+            commandLine.unshift(compiler.path);
+            if (compiler.target !== undefined)
+              commandLine.push(`--target=${compiler.target}`);
+
+            let compilerName =
+                compiler.path.substring(compiler.path.lastIndexOf(path.sep) + 1)
+                    .toLowerCase();
+            if (compilerName.endsWith('.exe'))
+              compilerName = compilerName.substring(0, compilerName.length - 4);
+
+            const ClangCLMode =
+                compilerName === 'cl' || compilerName === 'clang-cl';
+            const incFlag = ClangCLMode ? '/I' : '-I';
+            const defFlag = ClangCLMode ? '/D' : '-D';
+
+            fileGroup.compileCommandFragments?.forEach(commands => {
+              commands.split(/\s/g).forEach(
+                  command => { commandLine.push(command); });
+            });
+            fileGroup.includePath?.forEach(
+                include => { commandLine.push(`${incFlag}${include.path}`); });
+            fileGroup.defines?.forEach(
+                define => { commandLine.push(`${defFlag}${define}`); });
+            fileGroup.sources.forEach(source => {
+              const file = sourceDirectory.length != 0
+                               ? sourceDirectory + path.sep + source
+                               : source;
+              const command: protocol.ClangdCompileCommand = {
+                workingDirectory: sourceDirectory,
+                compilationCommand: commandLine
+              };
+              codeModelChanges.set(file, command);
+            });
+          });
+        });
+      });
+    });
+
+    const codeModel = new Map(codeModelChanges);
+    this.codeModel?.forEach((cc, file) => {
+      if (!codeModelChanges.has(file)) {
+        const command: protocol.ClangdCompileCommand = {
+          workingDirectory: '',
+          compilationCommand: []
+        };
+        codeModelChanges.set(file, command);
+        return;
+      }
+      const command = codeModelChanges.get(file);
+      if (command?.workingDirectory === cc.workingDirectory &&
+          command?.compilationCommand.length === cc.compilationCommand.length &&
+          command?.compilationCommand.every(
+              (val, index) => val === cc.compilationCommand[index])) {
+        codeModelChanges.delete(file);
+      }
+    });
+    this.codeModel = codeModel;
+
+    if (codeModelChanges.size === 0)
+      return;
+
+    codeModelChanges.forEach(
+        (cc, file) => {Object.assign(
+            request.settings.compilationDatabaseChanges, {[file]: cc})});
+
+    this.context.client.sendNotification(
+        protocol.DidChangeConfigurationRequest.type, request);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // stop/start cycle in this situation is pointless, and doesn't work
         // anyways because the client can't be stop()-ped when it's still in the
         // Starting state).
-        if (!clangdContext.clientIsReady()) {
+        if (clangdContext.clientIsStarting()) {
           return;
         }
         await clangdContext.dispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,15 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand('clangd.activate', async () => {}));
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
+        // clangd.restart can be called when the extension is not yet activated.
+        // In such a case, vscode will activate the extension and then run this
+        // handler. Detect this situation and bail out (doing an extra
+        // stop/start cycle in this situation is pointless, and doesn't work
+        // anyways because the client can't be stop()-ped when it's still in the
+        // Starting state).
+        if (!clangdContext.clientIsReady()) {
+          return;
+        }
         await clangdContext.dispose();
         await clangdContext.activate(context.globalStoragePath, outputChannel);
       }));

--- a/src/inactive-regions.ts
+++ b/src/inactive-regions.ts
@@ -104,5 +104,8 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
   }
 
   getState(): vscodelc.FeatureState { return {kind: 'static'}; }
-  dispose() {}
+
+  // clears inactive region decorations on disposal so they don't persist after
+  // extension is deactivated
+  dispose() { this.decorationType?.dispose(); }
 }

--- a/test/inactive-regions.test.ts
+++ b/test/inactive-regions.test.ts
@@ -16,7 +16,7 @@ class MockClangdContext implements ClangdContext {
 
   async activate() { throw new Error('Method not implemented.'); }
 
-  clientIsReady() { return true; }
+  clientIsStarting() { return false; }
 
   dispose() { throw new Error('Method not implemented.'); }
 }

--- a/test/inactive-regions.test.ts
+++ b/test/inactive-regions.test.ts
@@ -16,6 +16,8 @@ class MockClangdContext implements ClangdContext {
 
   async activate() { throw new Error('Method not implemented.'); }
 
+  clientIsReady() { return true; }
+
   dispose() { throw new Error('Method not implemented.'); }
 }
 


### PR DESCRIPTION
This PR add integration with [cmake-tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) extension. It uses exported API instead of querying the extension instance directly, so this integration must work with any cmake-tools forks, that implement this API.

This PR is cannot use as a complete replacement for `.clangd` configure file - it not pass `--query-driver` to clangd because clangd doesn't support change this via LSP. So this PR just alternative to export compile commands (clangd in VSCode now may work with `--compile_args_from=lsp` flag).

Resolves #233, #498