### PR TITLE
Restrict 'Show AST' menu to supported files only

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
                 },
                 {
                     "command": "clangd.ast",
-                    "when": "clangd.ast.supported"
+                    "when": "(resourceLangId == c || resourceLangId == cpp || resourceLangId == cuda-cpp || resourceLangId == objective-c || resourceLangId == objective-cpp) && clangd.ast.supported"
                 }
             ],
             "view/title": [


### PR DESCRIPTION
Just found "Show AST" menu will be shown in unrelated places like vscode output channel or even json file after clangd activated.

This patch restricts 'Show AST' menu to supported files only.