### PR TITLE
Implement clangd.shutdown to manually deactivate the extension (complement to clangd.activate; first half of clangd.restart). Addresses #512

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,11 @@
                 "title": "Manually activate extension"
             },
             {
+                "command": "clangd.shutdown",
+                "category": "clangd",
+                "title": "Manually shutdown extension"
+            },
+            {
                 "command": "clangd.restart",
                 "category": "clangd",
                 "title": "Restart language server"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,13 @@ export async function activate(context: vscode.ExtensionContext) {
   // An empty place holder for the activate command, otherwise we'll get an
   // "command is not registered" error.
   context.subscriptions.push(
-      vscode.commands.registerCommand('clangd.activate', async () => {}));
+      vscode.commands.registerCommand('clangd.activate', async () => {
+        await clangdContext.activate(context.globalStoragePath, outputChannel);
+      }));
+  context.subscriptions.push(
+      vscode.commands.registerCommand('clangd.shutdown', async () => {
+        await clangdContext.dispose();
+      }));
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
         await clangdContext.dispose();


### PR DESCRIPTION
This change is a proof of concept that builds the fix roughly as described in #512 and works to disable and enable clangd language server on command with clangd.shutdown and clangd.activate. clangd.shutdown is implemented with the "dispose" action used for clangd.restart, as proposed in the issue.

This still needs work to add some state checking of whether the language server is already shutdown, unregistration of commands that won't work if the language server is not running, or early-exit from said commands.