### PR TITLE
Label "close" commands for views; improve enablement

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,8 @@
             {
                 "command": "clangd.typeHierarchy.close",
                 "category": "clangd",
-                "title": "Close",
+                "enablement": "clangd.typeHierarchyView.visible",
+                "title": "Close type hierarchy view",
                 "icon": "$(panel-close)"
             },
             {
@@ -243,7 +244,8 @@
             {
                 "command": "clangd.memoryUsage.close",
                 "category": "clangd",
-                "title": "Close",
+                "enablement": "clangd.memoryUsage.visible",
+                "title": "Close memory usage view",
                 "icon": "$(panel-close)"
             },
             {
@@ -256,7 +258,8 @@
             {
                 "command": "clangd.ast.close",
                 "category": "clangd",
-                "title": "Close",
+                "enablement": "clangd.ast.visible",
+                "title": "Close AST view",
                 "icon": "$(panel-close)"
             },
             {


### PR DESCRIPTION
At the moment, the `Close` commands for each contributed view:
 - All have the same title `"Close"`
 - Are all enabled and visible in the command palette even if the corresponding view isn't actually visible

This PR
 - Adds details about the view to be closed to the title so that each is distinct
 - Uses a `${viewId}.visible` context key that is [automatically set up by VSCode](https://github.com/microsoft/vscode/blob/bccfade64adb249f57c8fcf03cba41609f76ce5c/src/vs/workbench/services/views/browser/viewDescriptorService.ts#L892) for each view to determine enablement.
