### PR TITLE
Allow setting compilation database directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,11 @@
                     "type": "number",
                     "default": 0.55,
                     "description": "Opacity of inactive regions (used only if clangd.inactiveRegions.useBackgroundHighlight=false)"
+                },
+                "clangd.compilationDatabaseDirectory": {
+                    "type": "string",
+                    "default": "",
+                    "decription": "Workspace-relative directory to search for a compilation database compile_commands.json file. Leave empty to use the workspace root."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "capabilities": {
         "untrustedWorkspaces": {
             "supported": "limited",
-            "description": "In restricted mode clangd.path and clangd.arguments are not respected.",
-            "restrictedConfigurations": ["clangd.path", "clangd.arguments"]
+            "description": "In restricted mode clangd.path, clangd.arguments and clangd.compilationDatabaseDirectory are not respected.",
+            "restrictedConfigurations": ["clangd.path", "clangd.arguments", "clangd.compilationDatabaseDirectory"]
         }
     },
     "contributes": {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -66,9 +66,14 @@ export class ClangdContext implements vscode.Disposable {
     if (!clangdPath)
       return;
 
+    const args = config.get<string[]>('arguments');
+    const dbDir = config.get<string>('compilationDatabaseDirectory');
+    if (!!dbDir)
+      args.push(`--compile-commands-dir=${dbDir}`);
+
     const clangd: vscodelc.Executable = {
       command: clangdPath,
-      args: await config.get<string[]>('arguments'),
+      args: args,
       options: {cwd: vscode.workspace.rootPath || process.cwd()}
     };
     const traceFile = config.get<string>('trace');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,13 @@ export async function activate(context: vscode.ExtensionContext) {
         await clangdContext.activate(context.globalStoragePath, outputChannel);
       }));
 
+  context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration(async (conf) => {
+        if (!conf.affectsConfiguration('clangd.compilationDatabaseDirectory'))
+          return;
+        vscode.commands.executeCommand('clangd.restart');
+      }));
+
   await clangdContext.activate(context.globalStoragePath, outputChannel);
 
   const shouldCheck = vscode.workspace.getConfiguration('clangd').get(


### PR DESCRIPTION
This change adds a configuration entry that allows you to specify a custom location for the `compile_commands.json` file. For example, this might be necessary if you are using the VS Code Meson extension, which by default uses `builddir` as the build directory containing the above file.

Or imagine you have a single workspace where you have two separate build directories with different feature flags enabled. Perhaps you are targeting multiple platforms in this way? You want to be able to quickly switch between these different configurations.

While you can achieve the same result by adding `--compile-commands-dir=...` to the `clangd.arguments` configuration variable, this is hardly discoverable by users. Adding a separate variable with a proper description will better expose the functionality.

Also, while `clangd.compilationDatabaseDirectory` is currently restricted to trusted workspaces only, a proper check on the validity of the specified path would allow this restriction to be removed, which cannot be said for the more general `clangd.arguments` parameter. Unfortunately, the VS Code API does not seem to expose any functionality to do this, and I am not able to do it safely myself.