### PR TITLE
Export client from activation as API for use in other extensions

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -9,9 +9,9 @@ import type { ClangdExtension, ASTParams, ASTNode } from '@clangd/vscode-clangd'
 const CLANGD_EXTENSION = 'llvm-vs-code-extensions.vscode-clangd';
 const CLANGD_API_VERSION = 1;
 
-const ASTType = 'textDocument/ast';
+const ASTRequestMethod = 'textDocument/ast';
 
-const provideHover = (document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken): Promise<vscode.Hover | undefined> => {
+const provideHover = async (document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken): Promise<vscode.Hover | undefined> => {
 
     const clangdExtension = vscode.extensions.getExtension<ClangdExtension>(CLANGD_EXTENSION);
 
@@ -22,11 +22,13 @@ const provideHover = (document: vscode.TextDocument, position: vscode.Position, 
         const range = api.languageClient.code2ProtocolConverter.asRange(new vscode.Range(position, position));
         const params: ASTParams = { textDocument, range };
  
-        const ast: ASTNode | undefined = await api.languageClient.sendRequest(ASTType, params);
+        const ast: ASTNode | undefined = await api.languageClient.sendRequest(ASTRequestMethod, params);
 
         return {
             contents: [ast.kind]
         };
     }
 };
+
+vscode.languages.registerHoverProvider(['c', 'cpp'], { provideHover });
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,30 @@
+# VS Code clangd Extension API
+
+The VS Code clangd extension exposes an API that other extensions can consume:
+
+```typescript
+import * as vscode from 'vscode';
+import type { ClangdExtension, ASTParams, ASTNode, ASTType } from '@clangd/vscode-clangd';
+
+const CLANGD_EXTENSION = 'llvm-vs-code-extensions.vscode-clangd';
+const CLANGD_API_VERSION = 1;
+
+const provideHover = (document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken): Promise<vscode.Hover | undefined> => {
+
+    const clangdExtension = vscode.extensions.getExtension<ClangdExtension>(CLANGD_EXTENSION);
+
+    if (clangdExtension) {
+        const api = (await clangdExtension.activate()).getApi(CLANGD_API_VERSION);
+ 
+        const textDocument = api.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document);
+        const range = api.languageClient.code2ProtocolConverter.asRange(new vscode.Range(position, position));
+        const params: ASTParams = { textDocument, range };
+ 
+        const ast: ASTNode | undefined = await api.languageClient.sendRequest(ASTType, params);
+
+        return {
+            contents: [ast.kind]
+        };
+    }
+};
+```

--- a/api/README.md
+++ b/api/README.md
@@ -4,10 +4,12 @@ The VS Code clangd extension exposes an API that other extensions can consume:
 
 ```typescript
 import * as vscode from 'vscode';
-import type { ClangdExtension, ASTParams, ASTNode, ASTType } from '@clangd/vscode-clangd';
+import type { ClangdExtension, ASTParams, ASTNode } from '@clangd/vscode-clangd';
 
 const CLANGD_EXTENSION = 'llvm-vs-code-extensions.vscode-clangd';
 const CLANGD_API_VERSION = 1;
+
+const ASTType = 'textDocument/ast';
 
 const provideHover = (document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken): Promise<vscode.Hover | undefined> => {
 

--- a/api/README.md
+++ b/api/README.md
@@ -24,6 +24,10 @@ const provideHover = async (document: vscode.TextDocument, position: vscode.Posi
  
         const ast: ASTNode | undefined = await api.languageClient.sendRequest(ASTRequestMethod, params);
 
+        if (!ast) {
+            return undefined;
+        }
+
         return {
             contents: [ast.kind]
         };

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@clangd/vscode-clangd",
+    "version": "0.0.0",
+    "description": "API for the llvm-vs-code-extensions.vscode-clangd VS Code extension",
+    "types": "vscode-clangd.d.ts",
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
+    },
+    "repository": "https://github.com/clangd/vscode-clangd",
+    "dependencies": {
+        "vscode-languageclient": "8.0.2"
+    }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,8 @@
         "registry": "https://npm.pkg.github.com"
     },
     "repository": "https://github.com/clangd/vscode-clangd",
+    "license": "MIT",
+    "homepage": "https://github.com/clangd/vscode-clangd/blob/master/api/README.md",
     "dependencies": {
         "vscode-languageclient": "8.0.2"
     }

--- a/api/vscode-clangd.d.ts
+++ b/api/vscode-clangd.d.ts
@@ -16,8 +16,6 @@ export interface ASTNode {
   range?: vscodelc.Range;
 }
 
-export const ASTType = 'textDocument/ast';
-
 export interface ClangdApiV1 {
   languageClient: BaseLanguageClient
 }

--- a/api/vscode-clangd.d.ts
+++ b/api/vscode-clangd.d.ts
@@ -1,0 +1,27 @@
+import {BaseLanguageClient} from 'vscode-languageclient';
+import * as vscodelc from 'vscode-languageclient/node';
+
+// The wire format: we send a position, and get back a tree of ASTNode.
+export interface ASTParams {
+  textDocument: vscodelc.TextDocumentIdentifier;
+  range: vscodelc.Range;
+}
+
+export interface ASTNode {
+  role: string;    // e.g. expression
+  kind: string;    // e.g. BinaryOperator
+  detail?: string; // e.g. ||
+  arcana?: string; // e.g. BinaryOperator <0x12345> <col:12, col:1> 'bool' '||'
+  children?: Array<ASTNode>;
+  range?: vscodelc.Range;
+}
+
+export const ASTType = 'textDocument/ast';
+
+export interface ClangdApiV1 {
+  languageClient: BaseLanguageClient
+}
+
+export interface ClangdExtension {
+  getApi(version: 1): ClangdApiV1;
+}

--- a/api/vscode-clangd.d.ts
+++ b/api/vscode-clangd.d.ts
@@ -1,12 +1,27 @@
 import {BaseLanguageClient} from 'vscode-languageclient';
 import * as vscodelc from 'vscode-languageclient/node';
 
-// The wire format: we send a position, and get back a tree of ASTNode.
+export interface ClangdApiV1 {
+  // vscode-clangd's language client which can be used to send requests to the clangd language server
+  // Standard requests: https://microsoft.github.io/language-server-protocol/specifications/specification-current
+  // clangd custom requests: https://clangd.llvm.org/extensions
+  languageClient: BaseLanguageClient
+}
+
+export interface ClangdExtension {
+  getApi(version: 1): ClangdApiV1;
+}
+
+// clangd custom request types (type declarations for other requests may be added later)
+
+// textDocument/ast wire format
+// Send: position
 export interface ASTParams {
   textDocument: vscodelc.TextDocumentIdentifier;
   range: vscodelc.Range;
 }
 
+// Receive: tree of ASTNode
 export interface ASTNode {
   role: string;    // e.g. expression
   kind: string;    // e.g. BinaryOperator
@@ -14,12 +29,4 @@ export interface ASTNode {
   arcana?: string; // e.g. BinaryOperator <0x12345> <col:12, col:1> 'bool' '||'
   children?: Array<ASTNode>;
   range?: vscodelc.Range;
-}
-
-export interface ClangdApiV1 {
-  languageClient: BaseLanguageClient
-}
-
-export interface ClangdExtension {
-  getApi(version: 1): ClangdApiV1;
 }

--- a/api/vscode-clangd.d.ts
+++ b/api/vscode-clangd.d.ts
@@ -2,9 +2,12 @@ import {BaseLanguageClient} from 'vscode-languageclient';
 import * as vscodelc from 'vscode-languageclient/node';
 
 export interface ClangdApiV1 {
-  // vscode-clangd's language client which can be used to send requests to the clangd language server
-  // Standard requests: https://microsoft.github.io/language-server-protocol/specifications/specification-current
-  // clangd custom requests: https://clangd.llvm.org/extensions
+  // vscode-clangd's language client which can be used to send requests to the
+  // clangd language server
+  // Standard requests:
+  // https://microsoft.github.io/language-server-protocol/specifications/specification-current
+  // clangd custom requests:
+  // https://clangd.llvm.org/extensions
   languageClient: BaseLanguageClient
 }
 
@@ -12,7 +15,8 @@ export interface ClangdExtension {
   getApi(version: 1): ClangdApiV1;
 }
 
-// clangd custom request types (type declarations for other requests may be added later)
+// clangd custom request types
+// (type declarations for other requests may be added later)
 
 // textDocument/ast wire format
 // Send: position

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,5 @@
 import {BaseLanguageClient} from 'vscode-languageclient';
-
-export interface ClangdApiV1 {
-  languageClient: BaseLanguageClient
-}
-
-export interface ClangdExtension {
-  getApi(version: 1): ClangdApiV1;
-}
+import {ClangdApiV1, ClangdExtension} from '../api/vscode-clangd';
 
 export class ClangdExtensionImpl implements ClangdExtension {
   constructor(

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,26 @@
+import {BaseLanguageClient} from 'vscode-languageclient';
+
+export interface ClangdApiV1 {
+  languageClient: BaseLanguageClient
+}
+
+export interface ClangdExtension {
+  getApi(version: 1): ClangdApiV1;
+}
+
+export class ClangdExtensionImpl implements ClangdExtension {
+  constructor(
+    private readonly client: BaseLanguageClient
+  ) { }
+
+  public getApi(version: 1): ClangdApiV1;
+  public getApi(version: number): unknown {
+    if (version === 1) {
+      return {
+        languageClient: this.client
+      };
+    }
+
+    throw new Error(`No API version ${version} found`);
+  }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,17 +1,14 @@
 import {BaseLanguageClient} from 'vscode-languageclient';
+
 import {ClangdApiV1, ClangdExtension} from '../api/vscode-clangd';
 
 export class ClangdExtensionImpl implements ClangdExtension {
-  constructor(
-    private readonly client: BaseLanguageClient
-  ) { }
+  constructor(private readonly client: BaseLanguageClient) {}
 
   public getApi(version: 1): ClangdApiV1;
   public getApi(version: number): unknown {
     if (version === 1) {
-      return {
-        languageClient: this.client
-      };
+      return {languageClient: this.client};
     }
 
     throw new Error(`No API version ${version} found`);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -4,7 +4,9 @@ import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
 import {ClangdContext} from './clangd-context';
-import {ASTParams, ASTNode, ASTType} from '../api/vscode-clangd';
+import type {ASTParams, ASTNode} from '../api/vscode-clangd';
+
+const ASTType = 'textDocument/ast';
 
 export function activate(context: ClangdContext) {
   const feature = new ASTFeature(context);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -6,7 +6,7 @@ import * as vscodelc from 'vscode-languageclient/node';
 import {ClangdContext} from './clangd-context';
 import type {ASTParams, ASTNode} from '../api/vscode-clangd';
 
-const ASTType = 'textDocument/ast';
+const ASTRequestMethod = 'textDocument/ast';
 
 export function activate(context: ClangdContext) {
   const feature = new ASTFeature(context);
@@ -14,7 +14,7 @@ export function activate(context: ClangdContext) {
 }
 
 const ASTRequestType =
-    new vscodelc.RequestType<ASTParams, ASTNode|null, void>(ASTType);
+    new vscodelc.RequestType<ASTParams, ASTNode|null, void>(ASTRequestMethod);
 
 class ASTFeature implements vscodelc.StaticFeature {
   constructor(private context: ClangdContext) {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -4,27 +4,15 @@ import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
 
 import {ClangdContext} from './clangd-context';
+import {ASTParams, ASTNode, ASTType} from '../api/vscode-clangd';
 
 export function activate(context: ClangdContext) {
   const feature = new ASTFeature(context);
   context.client.registerFeature(feature);
 }
 
-// The wire format: we send a position, and get back a tree of ASTNode.
-interface ASTParams {
-  textDocument: vscodelc.TextDocumentIdentifier;
-  range: vscodelc.Range;
-}
-interface ASTNode {
-  role: string;    // e.g. expression
-  kind: string;    // e.g. BinaryOperator
-  detail?: string; // e.g. ||
-  arcana?: string; // e.g. BinaryOperator <0x12345> <col:12, col:1> 'bool' '||'
-  children?: Array<ASTNode>;
-  range?: vscodelc.Range;
-}
 const ASTRequestType =
-    new vscodelc.RequestType<ASTParams, ASTNode|null, void>('textDocument/ast');
+    new vscodelc.RequestType<ASTParams, ASTNode|null, void>(ASTType);
 
 class ASTFeature implements vscodelc.StaticFeature {
   constructor(private context: ClangdContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { BaseLanguageClient } from 'vscode-languageclient';
 
 import {ClangdContext} from './clangd-context';
 
@@ -6,7 +7,7 @@ import {ClangdContext} from './clangd-context';
  *  This method is called when the extension is activated. The extension is
  *  activated the very first time a command is executed.
  */
-export async function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext): Promise<BaseLanguageClient> {
   const outputChannel = vscode.window.createOutputChannel('clangd');
   context.subscriptions.push(outputChannel);
 
@@ -67,4 +68,6 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     }, 5000);
   }
+
+  return clangdContext.client;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
-import type {BaseLanguageClient} from 'vscode-languageclient';
 import {ClangdContext} from './clangd-context';
+import {ClangdExtension, ClangdExtensionImpl} from './api';
 
 /**
  *  This method is called when the extension is activated. The extension is
  *  activated the very first time a command is executed.
  */
-export async function activate(context: vscode.ExtensionContext): Promise<BaseLanguageClient> {
+export async function activate(context: vscode.ExtensionContext): Promise<ClangdExtension> {
   const outputChannel = vscode.window.createOutputChannel('clangd');
   context.subscriptions.push(outputChannel);
 
@@ -68,5 +68,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<BaseLa
     }, 5000);
   }
 
-  return clangdContext.client;
+  return new ClangdExtensionImpl(clangdContext.client);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-import type { BaseLanguageClient } from 'vscode-languageclient';
-
+import type {BaseLanguageClient} from 'vscode-languageclient';
 import {ClangdContext} from './clangd-context';
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import {ClangdContext} from './clangd-context';
-import {ClangdExtension, ClangdExtensionImpl} from './api';
+import {ClangdExtension} from '../api/vscode-clangd';
+import {ClangdExtensionImpl} from './api';
 
 /**
  *  This method is called when the extension is activated. The extension is

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,16 @@
 import * as vscode from 'vscode';
-import {ClangdContext} from './clangd-context';
+
 import {ClangdExtension} from '../api/vscode-clangd';
+
 import {ClangdExtensionImpl} from './api';
+import {ClangdContext} from './clangd-context';
 
 /**
  *  This method is called when the extension is activated. The extension is
  *  activated the very first time a command is executed.
  */
-export async function activate(context: vscode.ExtensionContext): Promise<ClangdExtension> {
+export async function activate(context: vscode.ExtensionContext):
+    Promise<ClangdExtension> {
   const outputChannel = vscode.window.createOutputChannel('clangd');
   context.subscriptions.push(outputChannel);
 


### PR DESCRIPTION
This PR exports the language client so other VS Code extensions can take advantage of the clangd LSP features.

For example, domain specific functionality (e.g. intrinsics) could be implemented in a separate extension and trivially leverage the full-featured AST functionality exposed by clangd.

This has been tested and working with a trivial hover example:

```typescript
import * as vscode from 'vscode';
import { BaseLanguageClient, Range, TextDocumentIdentifier, RequestType } from 'vscode-languageclient';
import { ClangdExtension } from ''

const CLANGD_EXTENSION = 'llvm-vs-code-extensions.vscode-clangd';
const CLANGD_API_VERSION = 1;

interface ClangdApiV1 {
  languageClient: BaseLanguageClient
}

interface ClangdExtension {
  getApi(version: 1): ClangdApiV1;
}

interface ASTParams {
    textDocument: TextDocumentIdentifier;
    range: Range;
}

interface ASTNode {
    role: string;    // e.g. expression
    kind: string;    // e.g. BinaryOperator
    detail?: string; // e.g. ||
    arcana?: string; // e.g. BinaryOperator <0x12345> <col:12, col:1> 'bool' '||'
    children?: Array<ASTNode>;
    range?: Range;
}

// This should work, but an error about kind: auto is thrown :/
// const ASTRequestType = new RequestType<ASTParams, ASTNode|null, void>('textDocument/ast');
const AST_REQUEST_TYPE = 'textDocument/ast';

export class LanguageFeatures {
    public constructor(protected context: vscode.ExtensionContext) {
        context.subscriptions.push(
            vscode.languages.registerHoverProvider(['c', 'cpp'], {
                provideHover: (document, position, token) => this.provideHover(document, position, token)
            })
        );
    }

    protected async provideHover(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken): Promise<vscode.Hover | undefined> {
        try {
            const languageClient = await this.getLanguageClient();
            if (!languageClient) {
                return undefined;
            }

            const textDocument = languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document);
            const range = languageClient.code2ProtocolConverter.asRange(new vscode.Range(position, position));
            const params: ASTParams = { textDocument, range };
            const ast: ASTNode | undefined = await languageClient.sendRequest(AST_REQUEST_TYPE, params);

            if (!ast) {
                return undefined;
            }

            return {
                contents: [ast.kind]
            };
        } catch {
            // Ignore any errors
        }
    }

    protected async getLanguageClient(): Promise<BaseLanguageClient | undefined> {
        const extension = vscode.extensions.getExtension(CLANGD_EXTENSION);
        if (!extension) {
            return undefined;
        }

        const activated = await extension.activate() as ClangdExtension;
        const api = activated.getApi(CLANGD_API_VERSION);
        return api.languageClient;
    }
}

```