### PR TITLE
Gracefully handle 'clangd.restart' being invoked when the extension hasn't been activated yet

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -175,6 +175,10 @@ export class ClangdContext implements vscode.Disposable {
         (e) => isClangdDocument(e.document));
   }
 
+  clientIsReady() {
+    return this.client && this.client.state == vscodelc.State.Running;
+  }
+
   dispose() {
     this.subscriptions.forEach((d) => { d.dispose(); });
     if (this.client)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,15 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand('clangd.activate', async () => {}));
   context.subscriptions.push(
       vscode.commands.registerCommand('clangd.restart', async () => {
+        // clangd.restart can be called when the extension is not yet activated.
+        // In such a case, vscode will activate the extension and then run this
+        // handler. Detect this situation and bail out (doing an extra
+        // stop/start cycle in this situation is pointless, and doesn't work
+        // anyways because the client can't be stop()-ped when it's still in the
+        // Starting state).
+        if (!clangdContext.clientIsReady()) {
+          return;
+        }
         await clangdContext.dispose();
         await clangdContext.activate(context.globalStoragePath, outputChannel);
       }));

--- a/test/inactive-regions.test.ts
+++ b/test/inactive-regions.test.ts
@@ -16,6 +16,8 @@ class MockClangdContext implements ClangdContext {
 
   async activate() { throw new Error('Method not implemented.'); }
 
+  clientIsReady() { return true; }
+
   dispose() { throw new Error('Method not implemented.'); }
 }
 


### PR DESCRIPTION
Fixes https://github.com/clangd/vscode-clangd/issues/502