### PR TITLE
Fix check for clangd.restart being a no-op

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -191,8 +191,8 @@ export class ClangdContext implements vscode.Disposable {
         (e) => isClangdDocument(e.document));
   }
 
-  clientIsReady() {
-    return this.client && this.client.state == vscodelc.State.Running;
+  clientIsStarting() {
+    return this.client && this.client.state == vscodelc.State.Starting;
   }
 
   dispose() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // stop/start cycle in this situation is pointless, and doesn't work
         // anyways because the client can't be stop()-ped when it's still in the
         // Starting state).
-        if (!clangdContext.clientIsReady()) {
+        if (clangdContext.clientIsStarting()) {
           return;
         }
         await clangdContext.dispose();

--- a/test/inactive-regions.test.ts
+++ b/test/inactive-regions.test.ts
@@ -16,7 +16,7 @@ class MockClangdContext implements ClangdContext {
 
   async activate() { throw new Error('Method not implemented.'); }
 
-  clientIsReady() { return true; }
+  clientIsStarting() { return false; }
 
   dispose() { throw new Error('Method not implemented.'); }
 }


### PR DESCRIPTION
The intention was to only catch the case where the language server is already starting because running the restart command triggered activation of the plugin, but it was also catching the case where the language server wasn't running at all.

Fixes https://github.com/clangd/vscode-clangd/issues/599