### PR TITLE
Clear All Decorations in `dispose`

### DIFF
--- a/src/inactive-regions.ts
+++ b/src/inactive-regions.ts
@@ -104,5 +104,8 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
   }
 
   getState(): vscodelc.FeatureState { return {kind: 'static'}; }
-  dispose() {}
+
+  // clears inactive region decorations on disposal so they don't persist after
+  // extension is deactivated
+  dispose() { this.decorationType?.dispose(); }
 }


### PR DESCRIPTION
This PR fixes issue #600, by calling `dispose` for the `decorationType` member of `InactiveRegionsFeature` objects during their own disposal.  Doing so removes the applied decorations, preventing them from persisting after the the extension is stopped or restarted.  