### PR TITLE
Add option to enable/disable clangd

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,11 @@
                   "type": "boolean",
                   "default": true,
                   "description": "Enable hovers provided by the language server"
+                },
+                "clangd.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable clangd language server features"
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,8 @@ export async function activate(context: vscode.ExtensionContext):
     await clangdContext.activate(context.globalStoragePath, outputChannel);
 
     shouldCheck = vscode.workspace.getConfiguration('clangd').get<boolean>(
-      'detectExtensionConflicts') ?? false;
+                      'detectExtensionConflicts') ??
+                  false;
   }
 
   if (shouldCheck) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,10 +41,15 @@ export async function activate(context: vscode.ExtensionContext):
         }
       }));
 
-  await clangdContext.activate(context.globalStoragePath, outputChannel);
+  let shouldCheck = false;
 
-  const shouldCheck = vscode.workspace.getConfiguration('clangd').get(
-      'detectExtensionConflicts');
+  if (vscode.workspace.getConfiguration('clangd').get<boolean>('enable')) {
+    await clangdContext.activate(context.globalStoragePath, outputChannel);
+
+    shouldCheck = vscode.workspace.getConfiguration('clangd').get<boolean>(
+      'detectExtensionConflicts') ?? false;
+  }
+
   if (shouldCheck) {
     const interval = setInterval(function() {
       const cppTools = vscode.extensions.getExtension('ms-vscode.cpptools');


### PR DESCRIPTION
I know that this could be done by disabling the extension for a given workspace, but that requires everyone working in the repository to do that via the VS Code GUI. This allows the extension to be disabled in the workspace settings which can be committed to the repo.

In our organization we're looking to transition from using `cpptools` to `clangd` and having an easy way to have both extensions installed but only one enabled in a given workspace will be extremely helpful for us. We can already have a workspace that has been migrated to `clangd` disable Intellisense via `cpptools`, but there's no equivalent on the `clangd` side that I was able to find. For workspaces that haven't been migrated, `clangd` and `cpptools` will conflict until the `clangd` extension is disabled manually.