### PR TITLE
Add handling of predefined variable ${workspaceFolderBasename}

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,10 @@ function replacement(name: string): string|undefined {
       return path.dirname(vscode.window.activeTextEditor.document.uri.fsPath);
     return process.cwd();
   }
+  if (name === 'workspaceFolderBasename' && 
+      vscode.workspace.rootPath !== undefined) {
+    return path.basename(vscode.workspace.rootPath);
+  }
   const envPrefix = 'env:';
   if (name.startsWith(envPrefix))
     return process.env[name.substr(envPrefix.length)] ?? '';

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ function replacement(name: string): string|undefined {
       return path.dirname(vscode.window.activeTextEditor.document.uri.fsPath);
     return process.cwd();
   }
-  if (name === 'workspaceFolderBasename' && 
+  if (name === 'workspaceFolderBasename' &&
       vscode.workspace.rootPath !== undefined) {
     return path.basename(vscode.workspace.rootPath);
   }


### PR DESCRIPTION
It's useful in my scenario when I'm creating a build dir that name depends on the name of workspace