### PR TITLE
Update language client in exported API, on `clangd.restart`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import {BaseLanguageClient} from 'vscode-languageclient';
 import {ClangdApiV1, ClangdExtension} from '../api/vscode-clangd';
 
 export class ClangdExtensionImpl implements ClangdExtension {
-  constructor(public client: BaseLanguageClient) { }
+  constructor(public client: BaseLanguageClient) {}
 
   public getApi(version: 1): ClangdApiV1;
   public getApi(version: number): unknown {

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import {BaseLanguageClient} from 'vscode-languageclient';
 import {ClangdApiV1, ClangdExtension} from '../api/vscode-clangd';
 
 export class ClangdExtensionImpl implements ClangdExtension {
-  constructor(private readonly client: BaseLanguageClient) {}
+  constructor(public client: BaseLanguageClient) { }
 
   public getApi(version: 1): ClangdApiV1;
   public getApi(version: number): unknown {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,9 @@ import * as vscode from 'vscode';
 import {ClangdExtension} from '../api/vscode-clangd';
 
 import {ClangdExtensionImpl} from './api';
-import {ClangdContext} from './clangd-context';
+import { ClangdContext } from './clangd-context';
+
+let apiInstance: ClangdExtensionImpl | undefined;
 
 /**
  *  This method is called when the extension is activated. The extension is
@@ -34,6 +36,9 @@ export async function activate(context: vscode.ExtensionContext):
         }
         await clangdContext.dispose();
         await clangdContext.activate(context.globalStoragePath, outputChannel);
+        if (apiInstance) {
+          apiInstance.client = clangdContext.client;
+        }
       }));
 
   await clangdContext.activate(context.globalStoragePath, outputChannel);
@@ -72,5 +77,6 @@ export async function activate(context: vscode.ExtensionContext):
     }, 5000);
   }
 
-  return new ClangdExtensionImpl(clangdContext.client);
+  apiInstance = new ClangdExtensionImpl(clangdContext.client);
+  return apiInstance;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,9 +3,9 @@ import * as vscode from 'vscode';
 import {ClangdExtension} from '../api/vscode-clangd';
 
 import {ClangdExtensionImpl} from './api';
-import { ClangdContext } from './clangd-context';
+import {ClangdContext} from './clangd-context';
 
-let apiInstance: ClangdExtensionImpl | undefined;
+let apiInstance: ClangdExtensionImpl|undefined;
 
 /**
  *  This method is called when the extension is activated. The extension is


### PR DESCRIPTION
Fix for #648

This PR update language client in exported API, after clangd restarting.