### PR TITLE
Add recursive substitution of config variables

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,7 @@ function replacement(name: string): string|undefined {
   if (name.startsWith(configPrefix)) {
     const config = vscode.workspace.getConfiguration().get(
         name.substr(configPrefix.length));
-    return (typeof config === 'string') ? config : undefined;
+    return (typeof config === 'string') ? substitute(config) : undefined;
   }
 
   return undefined;


### PR DESCRIPTION
I am using [CMake Tools](https://github.com/microsoft/vscode-cmake-tools) extension which allows to set `cmake.buildDirectory` config variable.
I wanted to specify location of `compile_commands.json` through settings like so:
```json
"clangd.arguments": [
	"--compile-commands-dir=${config:cmake.buildDirectory}"
],
```
but I noticed that variables get resolved only once. `cmake.buildDirectory` can in turn contain another variable such as `${workplaceFolder}` in my case. For this, a recursive resolution would be needed.

I'm not sure whether a recursion limit would be desired or if PR breaks in any weird cases.