### PR TITLE
Add clangd.env config key

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,11 @@
                     "default": false,
                     "description": "Check for language server updates on startup."
                 },
+                "clangd.env": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Additional environment variables to be defined for the clangd server."
+                },
                 "clangd.onConfigChanged": {
                     "type": "string",
                     "default": "prompt",

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -69,7 +69,10 @@ export class ClangdContext implements vscode.Disposable {
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: await config.get<string[]>('arguments'),
-      options: {cwd: vscode.workspace.rootPath || process.cwd()}
+      options: {
+        cwd: vscode.workspace.rootPath || process.cwd(),
+        env: await config.get<object>('env')
+      }
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {


### PR DESCRIPTION
Useful to flexibly modify the behavior of clangd, i.e. to set the default locale