### PR TITLE
[#681] re-enable file watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
                 "clangd.onConfigChanged": {
                     "type": "string",
                     "default": "prompt",
-                    "description": "What to do when clangd configuration files are changed.",
+                    "description": "What to do when clangd configuration files are changed. Ignored for clangd 12+, which can reload such files itself.",
                     "enum": [
                         "prompt",
                         "restart",
@@ -155,6 +155,11 @@
                         "Automatically restart the server",
                         "Do nothing"
                     ]
+                },
+                "clangd.onConfigChangedForceEnable": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Force enable of \"On Config Changed\" option regardless of clangd version."
                 },
                 "clangd.detectExtensionConflicts": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
                 "clangd.onConfigChanged": {
                     "type": "string",
                     "default": "prompt",
-                    "description": "What to do when clangd configuration files are changed. Ignored for clangd 12+, which can reload such files itself.",
+                    "description": "What to do when clangd configuration files are changed.",
                     "enum": [
                         "prompt",
                         "restart",

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -179,11 +179,11 @@ export class ClangdContext implements vscode.Disposable {
     ast.activate(this);
     openConfig.activate(this);
     inactiveRegions.activate(this);
+    configFileWatcher.activate(this);
     this.client.start();
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);
     switchSourceHeader.activate(this);
-    configFileWatcher.activate(this);
   }
 
   get visibleClangdEditors(): vscode.TextEditor[] {

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -21,9 +21,7 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
 
   initialize(capabilities: vscodelc.ServerCapabilities,
              _documentSelector: vscodelc.DocumentSelector|undefined) {
-    if ((capabilities as ClangdClientCapabilities)
-            .compilationDatabase?.automaticReload)
-      return;
+
     this.context.subscriptions.push(new ConfigFileWatcher(this.context));
   }
   getState(): vscodelc.FeatureState { return {kind: 'static'}; }

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -21,7 +21,9 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
 
   initialize(capabilities: vscodelc.ServerCapabilities,
              _documentSelector: vscodelc.DocumentSelector|undefined) {
-
+    if (!config.get<boolean>("onConfigChangedForceEnable") && 
+        (capabilities as ClangdClientCapabilities).compilationDatabase?.automaticReload)
+      return;
     this.context.subscriptions.push(new ConfigFileWatcher(this.context));
   }
   getState(): vscodelc.FeatureState { return {kind: 'static'}; }


### PR DESCRIPTION
https://github.com/clangd/vscode-clangd/issues/681

Re-enable the functionality of file watcher since clangd's builtin restart functionality does not refresh opened files in vscode, leading to potentially misleading ifdef view