### PR TITLE
Restrict keybindings to supported files

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,12 +291,12 @@
                 "command": "clangd.switchheadersource",
                 "key": "Alt+o",
                 "mac": "Alt+cmd+o",
-                "when": "editorTextFocus"
+                "when": "(resourceLangId == c || resourceLangId == cpp || resourceLangId == cuda-cpp || resourceLangId == objective-c || resourceLangId == objective-cpp) && editorTextFocus"
             },
             {
                 "command": "clangd.typeHierarchy",
                 "key": "Shift+Alt+t",
-                "when": "editorTextFocus"
+                "when": "(resourceLangId == cpp || resourceLangId == cuda-cpp || resourceLangId == objective-c || resourceLangId == objective-cpp) && editorTextFocus"
             }
         ],
         "menus": {


### PR DESCRIPTION
The clangd extension does not restrict the default keybindings for the `clangd.switchheadersource` and `clangd.typeHierarchy` commands to supported language ids. This has the effect of blocking other extensions from using these shortcuts for actions. Using the same shortcut for providing similar functionality for familiarity can be desirable for other extensions.

This PR adds a check for the supported language ids to the `when` clauses.