### PR TITLE
Add Language-Specific Overrides for `clangd.fallbackFlags`

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
                 "clangd.fallbackFlags": {
                     "type": "array",
                     "default": [],
+                    "scope": "language-overridable",
                     "items": {
                         "type": "string"
                     },

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -78,12 +78,20 @@ export class ClangdContext implements vscode.Disposable {
     }
     const serverOptions: vscodelc.ServerOptions = clangd;
 
+    const editor = vscode.window.activeTextEditor;
+    const currentLanguageScope: vscode.ConfigurationScope | undefined = editor
+        ? { languageId: editor.document.languageId}
+        : undefined;
+
     const clientOptions: vscodelc.LanguageClientOptions = {
       // Register the server for c-family and cuda files.
       documentSelector: clangdDocumentSelector,
       initializationOptions: {
         clangdFileStatus: true,
-        fallbackFlags: config.get<string[]>('fallbackFlags')
+        fallbackFlags: config.get<string[]>(
+          "fallbackFlags",
+          currentLanguageScope
+        ),
       },
       outputChannel: outputChannel,
       // Do not switch to output window when clangd returns output.

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,10 @@ export function get<T>(
   scope?: vscode.ConfigurationScope | null
 ): T {
   if (key === "fallbackFlags" && scope) {
-    return substitute(
-      vscode.workspace.getConfiguration("clangd", scope).get<T>(key)!
-    );
+    const scopedConfig = vscode.workspace.getConfiguration("clangd", scope).get<T>(key);
+    if (scopedConfig) {
+      return substitute(scopedConfig);
+    }
   }
   return substitute(vscode.workspace.getConfiguration("clangd").get<T>(key)!);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,8 +3,16 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Gets the config value `clangd.<key>`. Applies ${variable} substitutions.
-export function get<T>(key: string): T {
-  return substitute(vscode.workspace.getConfiguration('clangd').get<T>(key)!);
+export function get<T>(
+  key: string,
+  scope?: vscode.ConfigurationScope | null
+): T {
+  if (key === "fallbackFlags" && scope) {
+    return substitute(
+      vscode.workspace.getConfiguration("clangd", scope).get<T>(key)!
+    );
+  }
+  return substitute(vscode.workspace.getConfiguration("clangd").get<T>(key)!);
 }
 
 // Sets the config value `clangd.<key>`. Does not apply substitutions.


### PR DESCRIPTION
**Add Language-Specific Overrides for `clangd.fallbackFlags`**

I think it'll be helpful for single file hints

Example configuration:

```json
{
    "[c]": {
        "clangd.fallbackFlags": [
            "-Wall",
            "-Wextra",
            "-std=c11"
        ]
    },
    "[cpp]": {
        "clangd.fallbackFlags": [
            "-Wall",
            "-Wextra",
            "-std=c++17"
        ]
    }
}
```

**Current Limitation**: 

When both `.c` and `.cpp` files are in the same folder, the extension uses the fallback flags of the language that first wakes the `clangd` extension. A manual restart of the language server is required when switching between files of different languages in the same workspace.
