### PR TITLE
Adding option to follow symlinks when resolving symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,11 @@
                   "type": "boolean",
                   "default": true,
                   "description": "Enable hovers provided by the language server"
+                },
+                "clangd.followSymlinks": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Follow symlinks when resolving a symbol"
                 }
             }
         },


### PR DESCRIPTION
When using clangd in vscode with Bazel — trying to do symbol resolution (Go To Definition, Go To Declaration) will result in a file being opened in the Bazel build intermediate folder. This PR adds a settings flag and middlewares on the symbol resolution functions to follow symlinks back to their actual source file.

This issue has been discussed on the clangd project itself a few years ago. [1](https://github.com/clangd/clangd/issues/197) [2](https://github.com/clangd/clangd/issues/544). From my reading whether or not to follow the symlinks was too deep in the compiler infrastructure itself to change on the LSP server, and that whether or not to follow the symlinks might be situationally dependent. 

I attempted to solve the issue using the `--path-mappings ` flag but it doesn't seem suitable for this situation. 

[Hedron's](https://github.com/hedronvision/bazel-compile-commands-extractor generator `compile_commands.json` also seemed like an opportunity to generate different compile commands but [3](https://github.com/hedronvision/bazel-compile-commands-extractor/issues/195) it doesn't seem like one could get *working* compile commands that aren't pointing into bazel's sandbox directory

Having it here behind a feature flag seems like a reasonable middle ground. Folks that need symlink resolution would be able to check the box, and uncheck it if they were getting funky behavior.

I've created a project [here](https://github.com/cgrinker/vscode-clang-symlink-example) to demonstrate the behavior

## Symbol Resolution
![image](https://github.com/user-attachments/assets/e55467f4-1723-4cae-b043-c90a7a89e9e2)
## Without Symlink Following
![image](https://github.com/user-attachments/assets/4ed805c0-9117-4c48-9ac3-c41324399d7c)
## With Symlink Following
![image](https://github.com/user-attachments/assets/f8eadea4-52c7-4cce-a7ed-e4161ac87223)
