### PR TITLE
fix #683 Restore VsCode 1.91 behavior of allowing scripts as executable

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -69,7 +69,7 @@ export class ClangdContext implements vscode.Disposable {
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: await config.get<string[]>('arguments'),
-      options: {cwd: vscode.workspace.rootPath || process.cwd()}
+      options: {cwd: vscode.workspace.rootPath || process.cwd(), shell: true}
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {


### PR DESCRIPTION
In VsCode 1.72 Node was updated to version 20, before this upgrade, it was possible to execute cmd/bat scripts as executable.

After this update this was suddenly broken.
Our use-case for using such a script has to do with the consistency of our clang-tooling.
We build clang-format, clang-tidy, clangd ... all together and put this in a package manager.
In the script, we first download these executables (when needed) and than start the downloaded clangd.
As such, when fixing an issue in clang-tidy, the same issue will get fixed in the clangd exe.
Without this script, it is impossible to automatically trigger this download and it introduces the risk that we do not update all the tooling to the latest version.