### PR TITLE
FIX: extension activate failed if there is a space in clangd path

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -67,7 +67,9 @@ export class ClangdContext implements vscode.Disposable {
       return;
 
     const clangd: vscodelc.Executable = {
-      command: clangdPath,
+      // Quote the path. With `shell: true`, this is needed
+      // in case the path contains spaces.
+      command: `"${clangdPath}"`,
       args: await config.get<string[]>('arguments'),
       options: {cwd: vscode.workspace.rootPath || process.cwd(), shell: true}
     };


### PR DESCRIPTION
The last change `0c2d40d7d6b8092309bd2c880a32e59c71472a80` add `shell: true` to clangd options, which cause the extension activate failed if there is a space in clangd's path.

Especially on windows, clangd installed under 'C:\Program Files\'