### PR TITLE
Support API usage when clangd is disabled

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import type { ClangdExtension, ASTParams, ASTNode } from '@clangd/vscode-clangd';
 
 const CLANGD_EXTENSION = 'llvm-vs-code-extensions.vscode-clangd';
-const CLANGD_API_VERSION = 1;
+const CLANGD_API_VERSION = 2;
 
 const ASTRequestMethod = 'textDocument/ast';
 
@@ -17,6 +17,11 @@ const provideHover = async (document: vscode.TextDocument, position: vscode.Posi
 
     if (clangdExtension) {
         const api = (await clangdExtension.activate()).getApi(CLANGD_API_VERSION);
+
+        // Extension may be disabled
+        if (!api.languageClient) {
+            return undefined;
+        }
  
         const textDocument = api.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document);
         const range = api.languageClient.code2ProtocolConverter.asRange(new vscode.Range(position, position));

--- a/api/vscode-clangd.d.ts
+++ b/api/vscode-clangd.d.ts
@@ -8,11 +8,22 @@ export interface ClangdApiV1 {
   // https://microsoft.github.io/language-server-protocol/specifications/specification-current
   // clangd custom requests:
   // https://clangd.llvm.org/extensions
-  languageClient: BaseLanguageClient
+  languageClient: BaseLanguageClient;
+}
+
+export interface ClangdApiV2 {
+  // vscode-clangd's language client which can be used to send requests to the
+  // clangd language server
+  // Standard requests:
+  // https://microsoft.github.io/language-server-protocol/specifications/specification-current
+  // clangd custom requests:
+  // https://clangd.llvm.org/extensions
+  languageClient: BaseLanguageClient | undefined;
 }
 
 export interface ClangdExtension {
   getApi(version: 1): ClangdApiV1;
+  getApi(version: 2): ClangdApiV2;
 }
 
 // clangd custom request types

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,14 +1,19 @@
 import {BaseLanguageClient} from 'vscode-languageclient';
 
-import {ClangdApiV1, ClangdExtension} from '../api/vscode-clangd';
+import {ClangdApiV1, ClangdApiV2, ClangdExtension} from '../api/vscode-clangd';
 
 export class ClangdExtensionImpl implements ClangdExtension {
-  constructor(public client: BaseLanguageClient) {}
+  constructor(public client: BaseLanguageClient|undefined) {}
 
   public getApi(version: 1): ClangdApiV1;
+  public getApi(version: 2): ClangdApiV2;
   public getApi(version: number): unknown {
-    if (version === 1) {
+    switch (version) {
+    case 1:
+    case 2: {
       return {languageClient: this.client};
+      break;
+    }
     }
 
     throw new Error(`No API version ${version} found`);

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -25,7 +25,7 @@ export function isClangdDocument(document: vscode.TextDocument) {
   return vscode.languages.match(clangdDocumentSelector, document);
 }
 
-class ClangdLanguageClient extends vscodelc.LanguageClient {
+export class ClangdLanguageClient extends vscodelc.LanguageClient {
   // Override the default implementation for failed requests. The default
   // behavior is just to log failures in the output panel, however output panel
   // is designed for extension debugging purpose, normal users will not open it,
@@ -58,7 +58,7 @@ class EnableEditsNearCursorFeature implements vscodelc.StaticFeature {
 
 export class ClangdContext implements vscode.Disposable {
   subscriptions: vscode.Disposable[] = [];
-  client!: ClangdLanguageClient;
+  client: ClangdLanguageClient|undefined;
 
   async activate(globalStoragePath: string,
                  outputChannel: vscode.OutputChannel) {

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -6,7 +6,9 @@ import * as config from './config';
 
 export function activate(context: ClangdContext) {
   if (config.get<string>('onConfigChanged') !== 'ignore') {
-    context.client.registerFeature(new ConfigFileWatcherFeature(context));
+    if (context.client) {
+      context.client.registerFeature(new ConfigFileWatcherFeature(context));
+    }
   }
 }
 

--- a/src/inactive-regions.ts
+++ b/src/inactive-regions.ts
@@ -21,9 +21,11 @@ export const NotificationType =
 
 export function activate(context: ClangdContext) {
   const feature = new InactiveRegionsFeature(context);
-  context.client.registerFeature(feature);
-  context.client.onNotification(NotificationType,
-                                feature.handleNotification.bind(feature));
+  if (context.client) {
+    context.client.registerFeature(feature);
+    context.client.onNotification(NotificationType,
+                                  feature.handleNotification.bind(feature));
+  }
 }
 
 export class InactiveRegionsFeature implements vscodelc.StaticFeature {
@@ -80,9 +82,12 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
   }
 
   handleNotification(params: InactiveRegionsParams) {
+    if (!this.context.client) {
+      return;
+    }
     const filePath = vscode.Uri.parse(params.textDocument.uri, true).fsPath;
     const ranges: vscode.Range[] = params.regions.map(
-        (r) => this.context.client.protocol2CodeConverter.asRange(r));
+        (r) => this.context.client!.protocol2CodeConverter.asRange(r));
     this.files.set(filePath, ranges);
     this.applyHighlights(filePath);
   }

--- a/src/memory-usage.ts
+++ b/src/memory-usage.ts
@@ -11,8 +11,10 @@ import * as vscodelc from 'vscode-languageclient/node';
 import {ClangdContext} from './clangd-context';
 
 export function activate(context: ClangdContext) {
-  const feature = new MemoryUsageFeature(context);
-  context.client.registerFeature(feature);
+  if (context.client) {
+    const feature = new MemoryUsageFeature(context);
+    context.client.registerFeature(feature);
+  }
 }
 
 // LSP wire format for this clangd feature.
@@ -58,9 +60,11 @@ class MemoryUsageFeature implements vscodelc.StaticFeature {
         vscode.window.registerTreeDataProvider('clangd.memoryUsage', adapter));
     this.context.subscriptions.push(
         vscode.commands.registerCommand('clangd.memoryUsage', async () => {
-          const usage =
-              await this.context.client.sendRequest(MemoryUsageRequest, {});
-          adapter.root = convert(usage, '<root>');
+          if (this.context.client) {
+            const usage =
+                await this.context.client.sendRequest(MemoryUsageRequest, {});
+            adapter.root = convert(usage, '<root>');
+          }
         }));
     this.context.subscriptions.push(vscode.commands.registerCommand(
         'clangd.memoryUsage.close', () => adapter.root = undefined));

--- a/src/switch-source-header.ts
+++ b/src/switch-source-header.ts
@@ -15,9 +15,9 @@ export const type =
             'textDocument/switchSourceHeader');
 }
 
-async function switchSourceHeader(client: vscodelc.LanguageClient):
-    Promise<void> {
-  if (!vscode.window.activeTextEditor)
+async function switchSourceHeader(client
+                                  ?: vscodelc.LanguageClient): Promise<void> {
+  if (!client || !vscode.window.activeTextEditor)
     return;
   const uri = vscode.Uri.file(vscode.window.activeTextEditor.document.fileName);
 


### PR DESCRIPTION
This PR marks the languageClient as potentially undefined in the API, fixing #721 

It includes changes to remove non-null assertion (`!`) operators as these can lead to undesired side affects including the issue raised in #721 