### PR TITLE
Restore VsCode 1.91 behavior of allowing scripts as executable

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -48,7 +48,7 @@ recommend to run `npm run format` before sending a patch.
 
 To create a new release, create a commit that:
 
-- increases the version number in `package.json`
+- increases the version number in `package.json` and `package-lock.json`
 - updates `CHANGELOG.md` to cover changes since the last release
 
 Our CI will recognize the commit and publish new versions to the VSCode

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
             "description": "In restricted mode clangd.path and clangd.arguments are not respected.",
             "restrictedConfigurations": [
                 "clangd.path",
+                "clangd.useScriptAsExecutable",
                 "clangd.arguments"
             ]
         }
@@ -102,6 +103,12 @@
                     "default": "clangd",
                     "scope": "machine-overridable",
                     "description": "The path to clangd executable, e.g.: /usr/bin/clangd."
+                },
+                "clangd.useScriptAsExecutable": {
+                    "type": "boolean",
+                    "default": "false",
+                    "scope": "machine-overridable",
+                    "description": "Allows the path to be a script e.g.: clangd.sh."
                 },
                 "clangd.arguments": {
                     "type": "array",

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -68,27 +68,26 @@ export class ClangdContext implements vscode.Disposable {
     if (!clangdPath)
       return null;
 
-    const useScriptAsExecutable =
-        await config.get<boolean>('useScriptAsExecutable');
-    const clangdArguments = await config.get<string[]>('arguments');
-
-    return new ClangdContext(clangdPath, clangdArguments, outputChannel,
-                             useScriptAsExecutable);
+    return new ClangdContext(clangdPath, outputChannel);
   }
 
-  private constructor(clangdPath: string, clangdArguments: string[],
-                      outputChannel: vscode.OutputChannel,
-                      useScriptAsExecutable: boolean) {
+  private constructor(clangdPath: string, outputChannel: vscode.OutputChannel) {
+    const useScriptAsExecutable = config.get<boolean>('useScriptAsExecutable');
+    let clangdArguments = config.get<string[]>('arguments');
     if (useScriptAsExecutable) {
       let quote = (str: string) => { return `"${str}"`; };
       clangdPath = quote(clangdPath)
-      for (var i = 0; i < clangdArguments.length; i++)
-      clangdArguments[i] = quote(clangdArguments[i]);
+      for (var i = 0; i < clangdArguments.length; i++) {
+        clangdArguments[i] = quote(clangdArguments[i]);
+      }
     }
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: clangdArguments,
-      options: {cwd: vscode.workspace.rootPath || process.cwd()}
+      options: {
+        cwd: vscode.workspace.rootPath || process.cwd(),
+        shell: useScriptAsExecutable
+      }
     };
     const traceFile = config.get<string>('trace');
     if (!!traceFile) {

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -68,13 +68,23 @@ export class ClangdContext implements vscode.Disposable {
     if (!clangdPath)
       return null;
 
+    const useScriptAsExecutable =
+        await config.get<boolean>('useScriptAsExecutable');
     const clangdArguments = await config.get<string[]>('arguments');
 
-    return new ClangdContext(clangdPath, clangdArguments, outputChannel);
+    return new ClangdContext(clangdPath, clangdArguments, outputChannel,
+                             useScriptAsExecutable);
   }
 
   private constructor(clangdPath: string, clangdArguments: string[],
-                      outputChannel: vscode.OutputChannel) {
+                      outputChannel: vscode.OutputChannel,
+                      useScriptAsExecutable: boolean) {
+    if (useScriptAsExecutable) {
+      let quote = (str: string) => { return `"${str}"`; };
+      clangdPath = quote(clangdPath)
+      for (var i = 0; i < clangdArguments.length; i++)
+      clangdArguments[i] = quote(clangdArguments[i]);
+    }
     const clangd: vscodelc.Executable = {
       command: clangdPath,
       args: clangdArguments,


### PR DESCRIPTION
In VsCode 1.72 Node was updated to version 20, before this upgrade, it was possible to execute cmd/bat scripts as executable.After this update this was suddenly broken.
     Our use-case for using such a script has to do with the consistency of our clang-tooling.
     We build clang-format, clang-tidy, clangd ... all together and put this in a package manager.
     In the script, we first download these executables (when needed) and than start the downloaded clangd.
     As such, when fixing an issue in clang-tidy, the same issue will get fixed in the clangd exe.
     Without this script, it is impossible to automatically trigger this download and it introduces the risk that we do not update all the tooling to the latest version.

Fixes clangd#683

In this reapply, we quote both the command line and the arguments, such that both can contain spaces.
We also introduce the option useScriptAsExecutable, such that this is only enabled when the user wants it.