### PR TITLE
Workaround the drive letter casing issue on windows.

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -108,9 +108,8 @@ export class ClangdContext implements vscode.Disposable {
             function fix_windows_drive_letter_casing(uri: vscode.Uri): string | undefined {
               // We can't just use process.platform === 'win32' because of remote development
 
-              // https://stackoverflow.com/a/64822303/4479969
               // detect windows paths
-              const isWindowsPathRegex = /^(?<drive>[a-z]:)?(?<path>(?:[\\]?(?:[\w !#()-]+|[.]{1,2})+)*[\\])?(?<filename>(?:[.]?[\w !#()-]+)+)?[.]?$/i;
+              const isWindowsPathRegex = /^(?<drive_letter>[a-zA-Z]):[\\\/](?<remainingPath>.*)/i;
 
               // Fix lower case drive letters on Windows
               const fsPath = uri.fsPath
@@ -123,17 +122,16 @@ export class ClangdContext implements vscode.Disposable {
               }
 
               // change the drive letter to uppercase
-              const drive = windowsPathMatch.groups?.drive?.toUpperCase() ?? '';
-              const path = windowsPathMatch.groups?.path ?? '';
-              const filename = windowsPathMatch.groups?.filename ?? '';
+              const drive_letter = windowsPathMatch.groups?.drive_letter?.toUpperCase() ?? '';
+              const remainingPath = windowsPathMatch.groups?.remainingPath ?? '';
 
-              if (!drive) {
+              if (!drive_letter) {
                 // no drive letter so there is nothing to fix
                 return undefined;
               }
 
               // Reconstruct the path
-              const fixed_uri = `file:///${drive}${path}${filename}`;
+              const fixed_uri = `file:///${drive_letter}:\\${remainingPath}`;
               return fixed_uri;
             }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "ES2022",
         "outDir": "out",
         "lib": [
-            "es6",
-            "es2015.core",
-            "es2015.collection",
-            "es2015.generator",
-            "es2015.iterable",
-            "es2015.promise",
-            "es2015.symbol",
-            "es2016.array.include",
-            "es2017.object"
+            "ES2022",
         ],
         "sourceMap": true,
         "rootDir": ".",


### PR DESCRIPTION
Fixes: #726.

Lower case drive letters seem to be the cause of the issues.

Not being able to refactor on windows makes `clangd` borderline unusable.

The workaround can be removed once https://github.com/clangd/clangd/issues/108 is fixed.
In the mean time I think this simple workaround should be quite robust and alleviates the pain.

## Why I fixed it here:

Working around the `clangd` issue in the vscode extension is much easier than attempting to tame the beast that is `clangd`.
The impact of the workaround is also very small.

## Some things I am uncertain about:

I don't know if `clangd` normalizes paths at all.
If it doesn't:

Maybe a setting should be added to decide between upper and lower case drive letter normalization on windows.
I have never observed lower case ones in `compile_commands.json` though.
So we should probably wait for complaints 😁 before adding the setting.

### Note:
I changed the typescript target because I needed named capture groups.
Maybe it is also time to move on from `commonjs` to `"module": "Node16",`.