### PR TITLE
Handle workspace symbols searches with a '::' prefix

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -185,6 +185,11 @@ export class ClangdContext implements vscode.Disposable {
             if (query.includes('::')) {
               if (symbol.containerName)
                 symbol.name = `${symbol.containerName}::${symbol.name}`;
+              // results from clangd strip the leading '::', so vscode fuzzy
+              // match will filter out all results unless we add prefix back in
+              if (query.startsWith('::')) {
+                symbol.name = `::${symbol.name}`;
+              }
               // Clean the containerName to avoid displaying it twice.
               symbol.containerName = '';
             }


### PR DESCRIPTION
There is some prior discussion in #31 that doesn't directly address this issue--it appears to me searching for a symbol with a leading `::` always fails: results from clangd strip the leading `::`, so vscode fuzzy match will filter out all results unless we add prefix back, which is easy enough to do.