### PR TITLE
Support commands in config

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -212,13 +212,17 @@ export class ClangdContext implements vscode.Disposable {
     this.subscriptions = subscriptions;
     this.client = client;
 
+    this.startClient();
+  }
+
+  async startClient() {
     typeHierarchy.activate(this);
     inlayHints.activate(this);
     memoryUsage.activate(this);
     ast.activate(this);
     openConfig.activate(this);
     inactiveRegions.activate(this);
-    configFileWatcher.activate(this);
+    await configFileWatcher.activate(this);
     this.client.start();
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -70,11 +70,15 @@ export class ClangdContext implements vscode.Disposable {
       return null;
     }
 
-    return new ClangdContext(subscriptions, await ClangdContext.createClient(clangdPath, outputChannel));
+    return new ClangdContext(subscriptions, await ClangdContext.createClient(
+                                                clangdPath, outputChannel));
   }
 
-  private static async createClient(clangdPath: string, outputChannel: vscode.OutputChannel): Promise<ClangdLanguageClient> {
-    const useScriptAsExecutable = await config.get<boolean>('useScriptAsExecutable');
+  private static async createClient(clangdPath: string,
+                                    outputChannel: vscode.OutputChannel):
+      Promise<ClangdLanguageClient> {
+    const useScriptAsExecutable =
+        await config.get<boolean>('useScriptAsExecutable');
     let clangdArguments = await config.get<string[]>('arguments');
     if (useScriptAsExecutable) {
       let quote = (str: string) => { return `"${str}"`; };
@@ -198,17 +202,17 @@ export class ClangdContext implements vscode.Disposable {
     };
 
     const client = new ClangdLanguageClient('Clang Language Server',
-                                           serverOptions, clientOptions);
-    client.clientOptions.errorHandler =
-        client.createDefaultErrorHandler(
-            // max restart count
-            await config.get<boolean>('restartAfterCrash') ? /*default*/ 4 : 0);
+                                            serverOptions, clientOptions);
+    client.clientOptions.errorHandler = client.createDefaultErrorHandler(
+        // max restart count
+        await config.get<boolean>('restartAfterCrash') ? /*default*/ 4 : 0);
     client.registerFeature(new EnableEditsNearCursorFeature);
 
     return client;
   }
 
-  private constructor(subscriptions: vscode.Disposable[], client: ClangdLanguageClient) {
+  private constructor(subscriptions: vscode.Disposable[],
+                      client: ClangdLanguageClient) {
     this.subscriptions = subscriptions;
     this.client = client;
 

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -19,9 +19,9 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
   constructor(private context: ClangdContext) {}
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
 
-  initialize(capabilities: vscodelc.ServerCapabilities,
+  async initialize(capabilities: vscodelc.ServerCapabilities,
              _documentSelector: vscodelc.DocumentSelector|undefined) {
-    if (!config.get<boolean>('onConfigChangedForceEnable') &&
+    if (!await config.get<boolean>('onConfigChangedForceEnable') &&
         (capabilities as ClangdClientCapabilities)
             .compilationDatabase?.automaticReload) {
       return;

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -4,8 +4,8 @@ import * as vscodelc from 'vscode-languageclient/node';
 import {ClangdContext} from './clangd-context';
 import * as config from './config';
 
-export function activate(context: ClangdContext) {
-  if (config.get<string>('onConfigChanged') !== 'ignore') {
+export async function activate(context: ClangdContext) {
+  if (await config.get<string>('onConfigChanged') !== 'ignore') {
     context.client.registerFeature(new ConfigFileWatcherFeature(context));
   }
 }
@@ -82,7 +82,7 @@ class ConfigFileWatcher implements vscode.Disposable {
     if ((await vscode.workspace.fs.stat(uri)).size <= 0)
       return;
 
-    switch (config.get<string>('onConfigChanged')) {
+    switch (await config.get<string>('onConfigChanged')) {
     case 'restart':
       vscode.commands.executeCommand('clangd.restart');
       break;

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -20,7 +20,7 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
   fillClientCapabilities(capabilities: vscodelc.ClientCapabilities) {}
 
   async initialize(capabilities: vscodelc.ServerCapabilities,
-             _documentSelector: vscodelc.DocumentSelector|undefined) {
+                   _documentSelector: vscodelc.DocumentSelector|undefined) {
     if (!await config.get<boolean>('onConfigChangedForceEnable') &&
         (capabilities as ClangdClientCapabilities)
             .compilationDatabase?.automaticReload) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,10 +71,14 @@ async function replacement(name: string): Promise<string|undefined> {
   }
   const commandPrefix = 'command:';
   if (name.startsWith(commandPrefix)) {
+    const commandId = name.substr(commandPrefix.length);
     try {
-      return await vscode.commands.executeCommand(
-          name.substr(commandPrefix.length));
-    } catch {
+      return await vscode.commands.executeCommand(commandId);
+    } catch (error) {
+      console.warn(`Clangd: Error resolving command '${commandId}':`, error);
+      vscode.window.showWarningMessage(
+          `Clangd: Failed to resolve ${commandId}`);
+
       return undefined;
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,8 @@ import * as vscode from 'vscode';
 
 // Gets the config value `clangd.<key>`. Applies ${variable} substitutions.
 export async function get<T>(key: string): Promise<T> {
-  return await substitute(vscode.workspace.getConfiguration('clangd').get<T>(key)!);
+  return await substitute(
+      vscode.workspace.getConfiguration('clangd').get<T>(key)!);
 }
 
 // Sets the config value `clangd.<key>`. Does not apply substitutions.
@@ -17,16 +18,17 @@ export function update<T>(key: string, value: T,
 async function substitute<T>(val: T): Promise<T> {
   if (typeof val === 'string') {
     const replacementPattern = /\$\{(.*?)\}/g;
-    const replacementPromises: Promise<string | undefined>[] = [];
+    const replacementPromises: Promise<string|undefined>[] = [];
     const matches = val.matchAll(replacementPattern);
     for (const match of matches) {
       // match[1] is the first captured group
       replacementPromises.push(replacement(match[1]));
     }
     const replacements = await Promise.all(replacementPromises);
-    val = val.replace(replacementPattern,
-      // If there's no replacement available, keep the placeholder.
-      match => replacements.shift() ?? match) as unknown as T;
+    val = val.replace(
+              replacementPattern,
+              // If there's no replacement available, keep the placeholder.
+              match => replacements.shift() ?? match) as unknown as T;
   } else if (Array.isArray(val)) {
     val = await Promise.all(val.map(substitute)) as T;
   } else if (typeof val === 'object') {
@@ -70,7 +72,8 @@ async function replacement(name: string): Promise<string|undefined> {
   const commandPrefix = 'command:';
   if (name.startsWith(commandPrefix)) {
     try {
-      return await vscode.commands.executeCommand(name.substr(commandPrefix.length));
+      return await vscode.commands.executeCommand(
+          name.substr(commandPrefix.length));
     } catch {
       return undefined;
     }

--- a/src/inactive-regions.ts
+++ b/src/inactive-regions.ts
@@ -45,16 +45,19 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
       };
     }
   }
-  async initialize(capabilities: vscodelc.ServerCapabilities,
-                   documentSelector: vscodelc.DocumentSelector|undefined) {
+  initialize(capabilities: vscodelc.ServerCapabilities,
+             documentSelector: vscodelc.DocumentSelector|undefined) {
     const serverCapabilities: vscodelc.ServerCapabilities&
         {inactiveRegionsProvider?: any} = capabilities;
     if (serverCapabilities.inactiveRegionsProvider) {
-      await this.updateDecorationType();
       this.context.subscriptions.push(
-          vscode.window.onDidChangeVisibleTextEditors(
-              (editors) => editors.forEach(
-                  (e) => this.applyHighlights(e.document.fileName))));
+          vscode.window.onDidChangeVisibleTextEditors(async (editors) => {
+            if (!this.decorationType) {
+              // If the decoration type is not yet initialized, update it
+              await this.updateDecorationType();
+            }
+            editors.forEach((e) => this.applyHighlights(e.document.fileName))
+          }));
       this.context.subscriptions.push(
           vscode.workspace.onDidChangeConfiguration(async (conf) => {
             const inactiveSettingsChanged =

--- a/src/inactive-regions.ts
+++ b/src/inactive-regions.ts
@@ -46,7 +46,7 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
     }
   }
   async initialize(capabilities: vscodelc.ServerCapabilities,
-             documentSelector: vscodelc.DocumentSelector|undefined) {
+                   documentSelector: vscodelc.DocumentSelector|undefined) {
     const serverCapabilities: vscodelc.ServerCapabilities&
         {inactiveRegionsProvider?: any} = capabilities;
     if (serverCapabilities.inactiveRegionsProvider) {
@@ -98,7 +98,8 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
     } else {
       this.decorationType = vscode.window.createTextEditorDecorationType({
         isWholeLine: true,
-        opacity: (await config.get<number>('inactiveRegions.opacity')).toString()
+        opacity:
+            (await config.get<number>('inactiveRegions.opacity')).toString()
       });
     }
   }

--- a/src/inactive-regions.ts
+++ b/src/inactive-regions.ts
@@ -45,18 +45,18 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
       };
     }
   }
-  initialize(capabilities: vscodelc.ServerCapabilities,
+  async initialize(capabilities: vscodelc.ServerCapabilities,
              documentSelector: vscodelc.DocumentSelector|undefined) {
     const serverCapabilities: vscodelc.ServerCapabilities&
         {inactiveRegionsProvider?: any} = capabilities;
     if (serverCapabilities.inactiveRegionsProvider) {
-      this.updateDecorationType();
+      await this.updateDecorationType();
       this.context.subscriptions.push(
           vscode.window.onDidChangeVisibleTextEditors(
               (editors) => editors.forEach(
                   (e) => this.applyHighlights(e.document.fileName))));
       this.context.subscriptions.push(
-          vscode.workspace.onDidChangeConfiguration((conf) => {
+          vscode.workspace.onDidChangeConfiguration(async (conf) => {
             const inactiveSettingsChanged =
                 conf.affectsConfiguration(
                     'clangd.inactiveRegions.useBackgroundHighlight') ||
@@ -65,7 +65,7 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
                   inactiveSettingsChanged))
               return;
             if (inactiveSettingsChanged) {
-              this.updateDecorationType();
+              await this.updateDecorationType();
             }
             vscode.window.visibleTextEditors.forEach((e) => {
               if (!this.decorationType)
@@ -87,9 +87,9 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
     this.applyHighlights(filePath);
   }
 
-  updateDecorationType() {
+  async updateDecorationType() {
     this.decorationType?.dispose();
-    if (config.get<boolean>('inactiveRegions.useBackgroundHighlight')) {
+    if (await config.get<boolean>('inactiveRegions.useBackgroundHighlight')) {
       this.decorationType = vscode.window.createTextEditorDecorationType({
         isWholeLine: true,
         backgroundColor:
@@ -98,7 +98,7 @@ export class InactiveRegionsFeature implements vscodelc.StaticFeature {
     } else {
       this.decorationType = vscode.window.createTextEditorDecorationType({
         isWholeLine: true,
-        opacity: config.get<number>('inactiveRegions.opacity').toString()
+        opacity: (await config.get<number>('inactiveRegions.opacity')).toString()
       });
     }
   }

--- a/src/install.ts
+++ b/src/install.ts
@@ -16,19 +16,21 @@ export async function activate(disposables: vscode.Disposable[],
       'clangd.install', async () => common.installLatest(ui)));
   disposables.push(vscode.commands.registerCommand(
       'clangd.update', async () => common.checkUpdates(true, ui)));
-  const status = await common.prepare(ui, await config.get<boolean>('checkUpdates'));
+  const status =
+      await common.prepare(ui, await config.get<boolean>('checkUpdates'));
   return status.clangdPath;
 }
 
 class UI {
-  static async create(disposables: vscode.Disposable[], globalStoragePath: string): Promise<UI> {
+  static async create(disposables: vscode.Disposable[],
+                      globalStoragePath: string): Promise<UI> {
     const ui = new UI(disposables, globalStoragePath);
     await ui.resolveClangdPath();
     return ui;
   }
 
   private constructor(private disposables: vscode.Disposable[],
-              private globalStoragePath: string) {}
+                      private globalStoragePath: string) {}
 
   get storagePath(): string { return this.globalStoragePath; }
   async choose(prompt: string, options: string[]): Promise<string|undefined> {
@@ -141,7 +143,7 @@ class UI {
     // relative to project root.
     if (!path.isAbsolute(p) && p.includes(path.sep) &&
         vscode.workspace.rootPath !== undefined) {
-          p = path.join(vscode.workspace.rootPath, p);
+      p = path.join(vscode.workspace.rootPath, p);
     }
 
     this._clangdPath = p;
@@ -149,9 +151,7 @@ class UI {
 
   private _clangdPath?: string = undefined;
 
-  get clangdPath(): string {
-    return this._clangdPath as string;
-  }
+  get clangdPath(): string { return this._clangdPath as string; }
   set clangdPath(p: string) {
     this._pathUpdated = new Promise(resolve => {
       config.update('path', p, vscode.ConfigurationTarget.Global).then(() => {

--- a/src/install.ts
+++ b/src/install.ts
@@ -11,17 +11,23 @@ import * as config from './config';
 export async function activate(disposables: vscode.Disposable[],
                                globalStoragePath: string):
     Promise<string|null> {
-  const ui = new UI(disposables, globalStoragePath);
+  const ui = await UI.create(disposables, globalStoragePath);
   disposables.push(vscode.commands.registerCommand(
       'clangd.install', async () => common.installLatest(ui)));
   disposables.push(vscode.commands.registerCommand(
       'clangd.update', async () => common.checkUpdates(true, ui)));
-  const status = await common.prepare(ui, config.get<boolean>('checkUpdates'));
+  const status = await common.prepare(ui, await config.get<boolean>('checkUpdates'));
   return status.clangdPath;
 }
 
 class UI {
-  constructor(private disposables: vscode.Disposable[],
+  static async create(disposables: vscode.Disposable[], globalStoragePath: string): Promise<UI> {
+    const ui = new UI(disposables, globalStoragePath);
+    await ui.resolveClangdPath();
+    return ui;
+  }
+
+  private constructor(private disposables: vscode.Disposable[],
               private globalStoragePath: string) {}
 
   get storagePath(): string { return this.globalStoragePath; }
@@ -129,18 +135,29 @@ class UI {
       common.installLatest(this);
   }
 
-  get clangdPath(): string {
-    let p = config.get<string>('path');
+  async resolveClangdPath() {
+    let p = await config.get<string>('path');
     // Backwards compatibility: if it's a relative path with a slash, interpret
     // relative to project root.
     if (!path.isAbsolute(p) && p.includes(path.sep) &&
-        vscode.workspace.rootPath !== undefined)
-      p = path.join(vscode.workspace.rootPath, p);
-    return p;
+        vscode.workspace.rootPath !== undefined) {
+          p = path.join(vscode.workspace.rootPath, p);
+    }
+
+    this._clangdPath = p;
+  }
+
+  private _clangdPath?: string = undefined;
+
+  get clangdPath(): string {
+    return this._clangdPath as string;
   }
   set clangdPath(p: string) {
     this._pathUpdated = new Promise(resolve => {
-      config.update('path', p, vscode.ConfigurationTarget.Global).then(resolve);
+      config.update('path', p, vscode.ConfigurationTarget.Global).then(() => {
+        this._clangdPath = p;
+        resolve();
+      });
     });
   }
 }

--- a/test/inactive-regions.test.ts
+++ b/test/inactive-regions.test.ts
@@ -28,7 +28,7 @@ suite('InactiveRegionsFeature', () => {
     sandbox = sinon.createSandbox();
     sandbox.stub(config, 'get')
         .withArgs('inactiveRegions.opacity')
-        .returns(0.55);
+        .returns(Promise.resolve(0.55));
   });
 
   teardown(() => { sandbox.restore(); });

--- a/test/inactive-regions.test.ts
+++ b/test/inactive-regions.test.ts
@@ -16,6 +16,8 @@ class MockClangdContext implements ClangdContext {
 
   async activate() { throw new Error('Method not implemented.'); }
 
+  async startClient() { throw new Error('Method not implemented.'); }
+
   clientIsStarting() { return false; }
 
   dispose() { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
Fix #48.

- Make `config.get` async, change all usage to support this.
- Add a new replacement for `command:` variables.