### PR TITLE
[#300] Re-enable the functionality of file watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
                 "clangd.onConfigChanged": {
                     "type": "string",
                     "default": "prompt",
-                    "description": "What to do when clangd configuration files are changed. Ignored for clangd 12+, which can reload such files itself.",
+                    "description": "What to do when clangd configuration files are changed. Ignored for clangd 12+, which can reload such files itself; however, this can be overridden with clangd.onConfigChanged.forceEnable.",
                     "enum": [
                         "prompt",
                         "restart",
@@ -164,6 +164,11 @@
                         "Automatically restart the server",
                         "Do nothing"
                     ]
+                },
+                "clangd.onConfigChanged.forceEnable": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Force enable of \"On Config Changed\" option regardless of clangd version."
                 },
                 "clangd.detectExtensionConflicts": {
                     "type": "boolean",

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -212,11 +212,11 @@ export class ClangdContext implements vscode.Disposable {
     ast.activate(this);
     openConfig.activate(this);
     inactiveRegions.activate(this);
+    configFileWatcher.activate(this);
     this.client.start();
     console.log('Clang Language Server is now active!');
     fileStatus.activate(this);
     switchSourceHeader.activate(this);
-    configFileWatcher.activate(this);
   }
 
   get visibleClangdEditors(): vscode.TextEditor[] {

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -21,9 +21,11 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
 
   initialize(capabilities: vscodelc.ServerCapabilities,
              _documentSelector: vscodelc.DocumentSelector|undefined) {
-    if ((capabilities as ClangdClientCapabilities)
-            .compilationDatabase?.automaticReload)
+    if (!config.get<boolean>('onConfigChanged.forceEnable') &&
+        (capabilities as ClangdClientCapabilities)
+            .compilationDatabase?.automaticReload) {
       return;
+    }
     this.context.subscriptions.push(new ConfigFileWatcher(this.context));
   }
   getState(): vscodelc.FeatureState { return {kind: 'static'}; }


### PR DESCRIPTION
This addresses this issue: https://github.com/clangd/vscode-clangd/issues/300
This is to take over this pull request: https://github.com/clangd/vscode-clangd/pull/688

Re-enable the functionality of file watcher since clangd's builtin restart functionality does not refresh opened files in vscode, leading to potentially misleading ifdef view.

I have addressed the comments on that PR.

