### PR TITLE
Disable clangd on untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,13 +73,8 @@
     "qna": "marketplace",
     "capabilities": {
         "untrustedWorkspaces": {
-            "supported": "limited",
-            "description": "In restricted mode clangd.path and clangd.arguments are not respected.",
-            "restrictedConfigurations": [
-                "clangd.path",
-                "clangd.useScriptAsExecutable",
-                "clangd.arguments"
-            ]
+            "supported": false,
+            "description": "Clangd isn't safe to run on untrusted code as it embeds clang as a parser. Parsing source files as one navigates a code base, carries the risk of being exploited."
         }
     },
     "contributes": {


### PR DESCRIPTION
Per
https://llvm.org/docs/Security.html#what-is-considered-a-security-issue,
parsing untrusted code through clang can result in harmful behavior.
Also it isn't considered as a security-sensitive component, hence its on
embedders like vscode-clangd to ensure users are aware of such risks.

Hence this patch disables running clangd on untrusted workspaces.
