### PR TITLE
Fix onConfigChanged.forceEnable

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
                 "clangd.onConfigChanged": {
                     "type": "string",
                     "default": "prompt",
-                    "description": "What to do when clangd configuration files are changed. Ignored for clangd 12+, which can reload such files itself; however, this can be overridden with clangd.onConfigChanged.forceEnable.",
+                    "description": "What to do when clangd configuration files are changed. Ignored for clangd 12+, which can reload such files itself; however, this can be overridden with clangd.onConfigChangedForceEnable.",
                     "enum": [
                         "prompt",
                         "restart",
@@ -160,7 +160,7 @@
                         "Do nothing"
                     ]
                 },
-                "clangd.onConfigChanged.forceEnable": {
+                "clangd.onConfigChangedForceEnable": {
                     "type": "boolean",
                     "default": false,
                     "description": "Force enable of \"On Config Changed\" option regardless of clangd version."

--- a/src/config-file-watcher.ts
+++ b/src/config-file-watcher.ts
@@ -21,7 +21,7 @@ class ConfigFileWatcherFeature implements vscodelc.StaticFeature {
 
   initialize(capabilities: vscodelc.ServerCapabilities,
              _documentSelector: vscodelc.DocumentSelector|undefined) {
-    if (!config.get<boolean>('onConfigChanged.forceEnable') &&
+    if (!config.get<boolean>('onConfigChangedForceEnable') &&
         (capabilities as ClangdClientCapabilities)
             .compilationDatabase?.automaticReload) {
       return;


### PR DESCRIPTION
`onConfigChanged.forceEnable` doesn't work due to a naming conflict with `onConfigChanged`. If the latter is defined then the former can't be set.

This PR simply renames `onConfigChanged.forceEnable` to `onConfigChangedForceEnable`.