### PR TITLE
dependabot: ignore updates to @types/vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
       npm-packages:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
This dependency defines the minimum supported version of VSCode, so we
want this to be a manual thing.
