### PR TITLE
Fix UI.localize function to use placeholders

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -59,7 +59,7 @@ class UI {
   localize(message: string, ...args: Array<string|number|boolean>): string {
     let ret = message;
     for (const i in args) {
-      ret.replace(`{${i}}`, args[i].toString());
+      ret = ret.replace(`{${i}}`, args[i].toString());
     }
     return ret;
   }


### PR DESCRIPTION
This change fixes error messages like `clangd {0} is now installed.` to include the interpolated string values (e.g. `clangd 20.1.0 is now installed.`).

`UI.localize` is a function that is [declared in `node-clangd`](https://github.com/clangd/node-clangd/blob/040ebbdcb135daf87053504ab4aaa13c1278de43/src/index.ts#L58-L69) that supports templating via substrings like `{0}` and `{1}`. `vscode-clangd` implements this templating with `String.prototype.replace`, which returns a new string rather than mutating the existing one.