### PR TITLE
feat(command): Add Create Source/Header Pair command

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,11 @@
                 "title": "Switch Between Source/Header"
             },
             {
+                "command": "clangd.createSourceHeaderPair",
+                "category": "clangd",
+                "title": "Create Source/Header Pair"
+            },
+            {
                 "command": "clangd.install",
                 "category": "clangd",
                 "title": "Download language server"
@@ -332,6 +337,11 @@
                     "group": "0_navigation@5"
                 },
                 {
+                    "command": "clangd.createSourceHeaderPair",
+                    "when": "resourceLangId == c || resourceLangId == cpp || resourceLangId == cuda-cpp || resourceLangId == objective-c || resourceLangId == objective-cpp",
+                    "group": "1_modification@1"
+                },
+                {
                     "command": "clangd.ast",
                     "when": "(resourceLangId == c || resourceLangId == cpp || resourceLangId == cuda-cpp || resourceLangId == objective-c || resourceLangId == objective-cpp) && clangd.ast.supported"
                 }
@@ -388,17 +398,20 @@
                 {
                     "id": "clangd.typeHierarchyView",
                     "name": "Type Hierarchy",
-                    "when": "clangd.typeHierarchyVisible"
+                    "when": "clangd.typeHierarchyVisible",
+                    "icon": "$(type-hierarchy)"
                 },
                 {
                     "id": "clangd.memoryUsage",
                     "name": "clangd Memory Usage",
-                    "when": "clangd.memoryUsage.hasData"
+                    "when": "clangd.memoryUsage.hasData",
+                    "icon": "$(dashboard)"
                 },
                 {
                     "id": "clangd.ast",
                     "name": "AST",
-                    "when": "clangd.ast.hasData"
+                    "when": "clangd.ast.hasData",
+                    "icon": "$(list-tree)"
                 }
             ]
         }

--- a/src/create-source-header-pair.ts
+++ b/src/create-source-header-pair.ts
@@ -1,0 +1,160 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as os from 'os';
+
+import { ClangdContext } from './clangd-context';
+
+// Handles the "Create Source/Header Pair" command.
+class PairCreator implements vscode.Disposable {
+  private command: vscode.Disposable;
+
+  constructor() {
+    this.command = vscode.commands.registerCommand(
+      'clangd.createSourceHeaderPair', this.create, this);
+  }
+
+  // Implements vscode.Disposable to clean up resources.
+  dispose() { this.command.dispose(); }
+
+  // Helper method to get platform-appropriate line ending
+  private getLineEnding(): string {
+    const eolSetting = vscode.workspace.getConfiguration('files').get<string>('eol');
+    if (eolSetting === '\n' || eolSetting === '\r\n') {
+      return eolSetting;
+
+    }
+    return os.EOL;
+  }
+
+  // The core implementation of the command.
+  // It handles user input, file creation, and opening the new file.
+  public async create() {
+    const targetDirectory = await this.getTargetDirectory();
+    if (!targetDirectory) {
+      vscode.window.showErrorMessage(
+        'Could not determine a target directory. Please open a folder or a file first.');
+      return;
+    }
+
+    const className = await vscode.window.showInputBox({
+      prompt: 'Please enter the name for the new C++ class.',
+      placeHolder: 'MyClass',
+      validateInput: text => {
+        if (!text || text.trim().length === 0) {
+          return 'Class name cannot be empty.';
+        }
+        if (!text.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
+          return 'Name must start with a letter or underscore and contain only letters, numbers, and underscores.';
+        }
+        return null;
+      }
+    });
+
+    if (!className) {
+      return; // User canceled the input
+    }
+
+    const headerPath =
+      vscode.Uri.file(path.join(targetDirectory.fsPath, `${className}.h`));
+    const sourcePath =
+      vscode.Uri.file(path.join(targetDirectory.fsPath, `${className}.cpp`));
+
+    // Prevent overwriting existing files
+    const [headerExists, sourceExists] = await Promise.allSettled([
+      vscode.workspace.fs.stat(headerPath),
+      vscode.workspace.fs.stat(sourcePath)
+    ]);
+
+    if (headerExists.status === 'fulfilled') {
+      vscode.window.showErrorMessage(
+        `File already exists: ${headerPath.fsPath}`);
+      return;
+    }
+    if (sourceExists.status === 'fulfilled') {
+      vscode.window.showErrorMessage(
+        `File already exists: ${sourcePath.fsPath}`);
+      return;
+    }
+
+
+    // Get the appropriate line ending for this platform/user setting
+    const eol = this.getLineEnding();
+
+    const headerGuard = `${className.toUpperCase()}_H_`;
+
+    // Define the content using clean template literals.
+    const headerTemplate = `#ifndef ${headerGuard}
+#define ${headerGuard}
+
+class ${className} {
+public:
+  ${className}();
+  ~${className}();
+
+private:
+  // Add private members here
+};
+
+#endif  // ${headerGuard}
+`;
+
+    const sourceTemplate = `#include "${className}.h"
+
+${className}::${className}() {
+  // Constructor implementation
+}
+
+${className}::~${className}() {
+  // Destructor implementation
+}
+`;
+
+    // Replace all LF (\n) characters in the templates with the correct EOL sequence.
+    const headerContent = headerTemplate.replace(/\n/g, eol);
+    const sourceContent = sourceTemplate.replace(/\n/g, eol);
+
+
+    try {
+      await Promise.all([
+        vscode.workspace.fs.writeFile(headerPath, Buffer.from(headerContent, 'utf8')),
+        vscode.workspace.fs.writeFile(sourcePath, Buffer.from(sourceContent, 'utf8'))
+      ]);
+    } catch (error: any) {
+      vscode.window.showErrorMessage(
+        `Failed to create files: ${error.message}`);
+      return;
+    }
+
+    await vscode.window.showTextDocument(
+      await vscode.workspace.openTextDocument(headerPath));
+    await vscode.window.showInformationMessage(
+      `Successfully created ${className}.h and ${className}.cpp`);
+  }
+
+  // Helper method to intelligently determine the directory for new files.
+  private async getTargetDirectory(): Promise<vscode.Uri | undefined> {
+    if (vscode.window.activeTextEditor && !vscode.window.activeTextEditor.document.isUntitled) {
+      return vscode.Uri.file(
+        path.dirname(vscode.window.activeTextEditor.document.uri.fsPath));
+    }
+
+    if (vscode.workspace.workspaceFolders &&
+      vscode.workspace.workspaceFolders.length > 0) {
+      if (vscode.workspace.workspaceFolders.length === 1) {
+        return vscode.workspace.workspaceFolders[0].uri;
+      }
+      const picked = await vscode.window.showWorkspaceFolderPick({
+        placeHolder: 'Please select a workspace folder to create the files in'
+      });
+      return picked?.uri;
+    }
+
+    return undefined;
+  }
+}
+
+// Registers the command and lifecycle handler for the create pair feature.
+export function registerCreateSourceHeaderPairCommand(context: ClangdContext) {
+  context.subscriptions.push(new PairCreator());
+
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,9 @@ import {ClangdExtension} from '../api/vscode-clangd';
 import {ClangdExtensionImpl} from './api';
 import {ClangdContext} from './clangd-context';
 import {get, update} from './config';
+import {
+  registerCreateSourceHeaderPairCommand
+} from './create-source-header-pair';
 
 let apiInstance: ClangdExtensionImpl|undefined;
 
@@ -52,8 +55,11 @@ export async function activate(context: vscode.ExtensionContext):
           clangdContext.dispose();
         clangdContext = await ClangdContext.create(context.globalStoragePath,
                                                    outputChannel);
-        if (clangdContext)
+        if (clangdContext) {
           context.subscriptions.push(clangdContext);
+
+          registerCreateSourceHeaderPairCommand(clangdContext);
+        }
         if (apiInstance) {
           apiInstance.client = clangdContext?.client;
         }
@@ -64,8 +70,11 @@ export async function activate(context: vscode.ExtensionContext):
   if (vscode.workspace.getConfiguration('clangd').get<boolean>('enable')) {
     clangdContext =
         await ClangdContext.create(context.globalStoragePath, outputChannel);
-    if (clangdContext)
+    if (clangdContext) {
       context.subscriptions.push(clangdContext);
+
+      registerCreateSourceHeaderPairCommand(clangdContext);
+    }
 
     shouldCheck = vscode.workspace.getConfiguration('clangd').get<boolean>(
                       'detectExtensionConflicts') ??


### PR DESCRIPTION
Improves the C++ development workflow by providing a new command to create corresponding source and header files simultaneously, mirroring common IDE functionality.

This new command, `clangd.createSourceHeaderPair`, provides the following features:
- Prompts the user for a valid C++ class name with robust validation.
- Intelligently detects the target directory, preferring the active file's location.
- Generates professional-grade file templates for both the header and source file.
- Handles cross-platform line endings (EOL) correctly by respecting user settings.
- Prevents accidental file overwrites by checking for existing files before creation.
- Is accessible from the Command Palette and the editor context menu.

Resolves #[839]