### PR TITLE
Type hierarchy view improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,13 +248,13 @@
                 "command": "clangd.typeHierarchy.viewParents",
                 "category": "clangd",
                 "title": "Types: Show Base Classes",
-                "icon": "$(triangle-up)"
+                "icon": "$(type-hierarchy-super)"
             },
             {
                 "command": "clangd.typeHierarchy.viewChildren",
                 "category": "clangd",
                 "title": "Types: Show Derived Classes",
-                "icon": "$(triangle-down)"
+                "icon": "$(type-hierarchy-sub)"
             },
             {
                 "command": "clangd.typeHierarchy.close",

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -317,9 +317,7 @@ class TypeHierarchyProvider implements
 
       this._onDidChangeTreeData.fire(null);
 
-      // This focuses the "explorer" view container which contains the
-      // type hierarchy view.
-      vscode.commands.executeCommand('workbench.view.explorer');
+      vscode.commands.executeCommand('clangd.typeHierarchyView.focus');
 
       // This expands and focuses the type hierarchy view.
       // Focus the item on which the operation was invoked, not the

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -73,6 +73,8 @@ const dummyNode: TypeHierarchyItem = {
 class TypeHierarchyTreeItem extends vscode.TreeItem {
   constructor(item: TypeHierarchyItem, direction: TypeHierarchyDirection) {
     super(item.name);
+    this.description = item.detail;
+    this.iconPath = new vscode.ThemeIcon('symbol-class');
     let subItems = direction === TypeHierarchyDirection.Children ? item.children : item.parents;
     if (subItems) {
       if (subItems.length === 0) {

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -71,10 +71,11 @@ const dummyNode: TypeHierarchyItem = {
 };
 
 class TypeHierarchyTreeItem extends vscode.TreeItem {
-  constructor(item: TypeHierarchyItem) {
+  constructor(item: TypeHierarchyItem, direction: TypeHierarchyDirection) {
     super(item.name);
-    if (item.children) {
-      if (item.children.length === 0) {
+    let subItems = direction === TypeHierarchyDirection.Children ? item.children : item.parents;
+    if (subItems) {
+      if (subItems.length === 0) {
         this.collapsibleState = vscode.TreeItemCollapsibleState.None;
       } else {
         this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
@@ -224,7 +225,7 @@ class TypeHierarchyProvider implements
   }
 
   public getTreeItem(element: TypeHierarchyItem): vscode.TreeItem {
-    return new TypeHierarchyTreeItem(element);
+    return new TypeHierarchyTreeItem(element, this.direction);
   }
 
   public getParent(element: TypeHierarchyItem): TypeHierarchyItem|null {

--- a/src/type-hierarchy.ts
+++ b/src/type-hierarchy.ts
@@ -258,9 +258,11 @@ class TypeHierarchyProvider implements
           await this.client.sendRequest(ResolveTypeHierarchyRequest.type, {
             item: element,
             direction: TypeHierarchyDirection.Children,
-            resolve: 1
+            resolve: 2 // We need 2 levels to understand which collapsible state to use
           });
       element.children = resolved?.children;
+      // Cut-of existing sub-children to resolve them later
+      element.children?.forEach(x => { if (x.children?.length !== 0) { x.children = undefined; } }); 
     }
     return element.children ?? [];
   }


### PR DESCRIPTION
- Fix collapsible state for classes without children.
- Fix base-classes hierarchy displaying for classes without children.
- Improve icons and details information like native vscode Peek Type Hierarchy.
