### PR TITLE
Fixes clangd/vscode-clangd#892

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,21 @@
                     "scope": "machine-overridable",
                     "description": "The path to clangd executable, e.g.: /usr/bin/clangd."
                 },
+                "clangd.linux.path": {
+                    "type": "string",
+                    "scope": "machine-overridable",
+                    "description": "Overrides the clangd.path setting on Linux, e.g.: /usr/bin/clangd."
+                },
+                "clangd.win32.path": {
+                    "type": "string",
+                    "scope": "machine-overridable",
+                    "description": "Overrides the clangd.path setting on Windows, e.g.: C:\\Program Files\\clangd\\clangd.exe."
+                },
+                "clangd.darwin.path": {
+                    "type": "string",
+                    "scope": "machine-overridable",
+                    "description": "Overrides the clangd.path setting on macOS, e.g.: /Applications/clangd.app/Contents/MacOS/clangd."
+                },
                 "clangd.useScriptAsExecutable": {
                     "type": "boolean",
                     "default": false,
@@ -111,6 +126,27 @@
                         "type": "string"
                     },
                     "description": "Arguments for clangd server."
+                },
+                "clangd.linux.arguments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Overrides the clangd.arguments for clangd server on Linux."
+                },
+                "clangd.win32.arguments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Overrides the clangd.arguments for clangd server on Windows."
+                },
+                "clangd.darwin.arguments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Overrides the clangd.arguments for clangd server on macOS."
                 },
                 "clangd.trace": {
                     "type": "string",
@@ -129,6 +165,27 @@
                         "type": "string"
                     },
                     "description": "Extra clang flags used to parse files when no compilation database is found."
+                },
+                "clangd.linux.fallbackFlags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Overrides the clangd.fallbackFlags for clangd server on Linux."
+                },
+                "clangd.win32.fallbackFlags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Overrides the clangd.fallbackFlags for clangd server on Windows."
+                },
+                "clangd.darwin.fallbackFlags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Overrides the clangd.fallbackFlags for clangd server on macOS."
                 },
                 "clangd.serverCompletionRanking": {
                     "type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,14 @@ import * as vscode from 'vscode';
 
 // Gets the config value `clangd.<key>`. Applies ${variable} substitutions.
 export async function get<T>(key: string): Promise<T> {
-  return await substitute(
-      vscode.workspace.getConfiguration('clangd').get<T>(key)!);
+  const platform = process.platform;
+  const config = vscode.workspace.getConfiguration('clangd');
+  let value = config.get<T>(`${platform}.${key}`);
+  if (value !== undefined) {
+    return await substitute(value);
+  }
+  value = config.get<T>(key);
+  return await substitute(value!);
 }
 
 // Sets the config value `clangd.<key>`. Does not apply substitutions.


### PR DESCRIPTION
add platform specific overrrides for settings for executable name, arguments for the executable and extra compile flags