### PR TITLE
Bump the vscode-languageclient dependency in api/package.json to 10.00-next

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,6 @@
     "license": "MIT",
     "homepage": "https://github.com/clangd/vscode-clangd/blob/master/api/README.md",
     "dependencies": {
-        "vscode-languageclient": "8.0.2"
+        "vscode-languageclient": "10.0.0-next.20"
     }
 }


### PR DESCRIPTION
This is needed to pick up the fix for
https://github.com/microsoft/vscode-languageserver-node/issues/1590, which is needed to compile with newer typescript versions.

Fixes https://github.com/clangd/vscode-clangd/issues/931