### PR TITLE
Fix completion crash when item.range starts using {inserting, replacing}

### DIFF
--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -148,7 +148,7 @@ export class ClangdContext implements vscode.Disposable {
               prefix = document.getText(new vscode.Range(start, position));
             }
             if (prefix)
-            item.filterText = prefix + '_' + item.filterText;
+              item.filterText = prefix + '_' + item.filterText;
             // Workaround for https://github.com/clangd/vscode-clangd/issues/357
             // clangd's used of commit-characters was well-intentioned, but
             // overall UX is poor. Due to vscode-languageclient bugs, we didn't

--- a/src/clangd-context.ts
+++ b/src/clangd-context.ts
@@ -138,8 +138,15 @@ export class ClangdContext implements vscode.Disposable {
           let items = (!list ? [] : Array.isArray(list) ? list : list.items);
           items = items.map(item => {
             // Gets the prefix used by VSCode when doing fuzzymatch.
-            let prefix = document.getText(
-                new vscode.Range((item.range as vscode.Range).start, position))
+            // item.range is either a Range or {inserting, replacing} (see
+            // CompletionItem in the VS Code API); narrow before using.
+            let prefix = '';
+            if (item.range) {
+              const start = item.range instanceof vscode.Range
+                                ? item.range.start
+                                : item.range.inserting.start;
+              prefix = document.getText(new vscode.Range(start, position));
+            }
             if (prefix)
             item.filterText = prefix + '_' + item.filterText;
             // Workaround for https://github.com/clangd/vscode-clangd/issues/357


### PR DESCRIPTION
The LSP spec (since 3.16) allows CompletionItem.range to be either a plain Range or an InsertReplaceRange ({inserting, replacing}). The old code cast item.range directly to vscode.Range; once clangd starts sending the newer form, this will crash (llvm/llvm-project#187623).

Narrow the type before extracting the start position, and guard against a missing range entirely.