### PR TITLE
fix: include LICENSE in VSIX package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,5 +3,6 @@
 !*.png
 !doc-assets/**
 !icon.png
+!LICENSE
 !out/bundle.js
 !package.json


### PR DESCRIPTION
## Summary
- allow the root LICENSE file through `.vscodeignore`
- ensure the packaged VSIX includes the extension license file

Closes #958

## Testing
- npm test
- npm run package
- verified the generated VSIX now contains `LICENSE.txt`
