### PR TITLE
Add support for setting OS specific paths for clangd

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,9 +4,13 @@
 
 This extension allows configuring command-line flags to the `clangd` executable.
 
+You can set `clangd.path` globally, or use platform-specific overrides:
+`clangd.path.linux`, `clangd.path.osx`, and `clangd.path.windows`.
+Don't specify `clangd.path` if you want to use the platform specific settings as Visual Studio Code will discard these in this case.
+
 Being able to configure these per-workspace can be convenient, but runs the risk
 of an attacker changing your flags if you happen to open their repository.
-Similarly, allowing the workspace to control the `clangd.path` setting is risky.
+Similarly, allowing the workspace to control the `clangd.path` settings is risky.
 
 When these flags are configured in the workspace, the extension will prompt you
 whether to use them or not. If you're unsure, click "No".

--- a/package.json
+++ b/package.json
@@ -98,6 +98,33 @@
                     "scope": "machine-overridable",
                     "description": "The path to clangd executable, e.g.: /usr/bin/clangd."
                 },
+                "clangd.path.linux": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "scope": "machine-overridable",
+                    "description": "The path to clangd executable on Linux, e.g.: /usr/bin/clangd. Overrides clangd.path on Linux when set."
+                },
+                "clangd.path.osx": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "scope": "machine-overridable",
+                    "description": "The path to clangd executable on macOS, e.g.: /opt/homebrew/bin/clangd. Overrides clangd.path on macOS when set."
+                },
+                "clangd.path.windows": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "scope": "machine-overridable",
+                    "description": "The path to clangd executable on Windows, e.g.: C:/Program Files/LLVM/bin/clangd.exe. Overrides clangd.path on Windows when set."
+                },
                 "clangd.useScriptAsExecutable": {
                     "type": "boolean",
                     "default": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,10 +8,39 @@ export async function get<T>(key: string): Promise<T> {
       vscode.workspace.getConfiguration('clangd').get<T>(key)!);
 }
 
+// Gets clangd.path with platform-specific override support:
+// clangd.path.<linux|osx|windows> falls back to clangd.path.
+export async function getPath(): Promise<string> {
+  const platformKey = currentPlatformKey();
+  if (platformKey) {
+    const platformPath = await substitute(vscode.workspace
+                                              .getConfiguration('clangd')
+                                              .get<string|null>(
+                                                  `path.${platformKey}`));
+    if (platformPath) {
+      return platformPath;
+    }
+  }
+  return await get<string>('path');
+}
+
 // Sets the config value `clangd.<key>`. Does not apply substitutions.
 export function update<T>(key: string, value: T,
                           target?: vscode.ConfigurationTarget) {
   return vscode.workspace.getConfiguration('clangd').update(key, value, target);
+}
+
+function currentPlatformKey(): 'linux'|'osx'|'windows'|null {
+  switch (process.platform) {
+    case 'linux':
+      return 'linux';
+    case 'darwin':
+      return 'osx';
+    case 'win32':
+      return 'windows';
+    default:
+      return null;
+  }
 }
 
 // Traverse a JSON value, replacing placeholders in all strings.

--- a/src/install.ts
+++ b/src/install.ts
@@ -138,7 +138,7 @@ class UI {
   }
 
   async resolveClangdPath() {
-    let p = await config.get<string>('path');
+    let p = await config.getPath();
     // Backwards compatibility: if it's a relative path with a slash, interpret
     // relative to project root.
     if (!path.isAbsolute(p) && p.includes(path.sep) &&


### PR DESCRIPTION
Allow setting the paths to the clangd executable depending on the platform. When using the platform specific setting don't use clang.path as this setting will discard all platform specific settings.

This PR was co-authored with AI and tested locally.