### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 0.6.0: May 21, 2026
+
+* Stable release of changes in version 0.5.0.
+
 ## Version 0.5.0: May 9, 2026
 
 * Support InsertReplaceEdit in code completion middleware [#954](https://github.com/clangd/vscode-clangd/pull/954).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-clangd",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-clangd",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "license": "MIT",
             "dependencies": {
                 "@clangd/install": "0.1.20",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-clangd",
     "displayName": "clangd",
     "description": "C/C++ completion, navigation, and insights",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "publisher": "llvm-vs-code-extensions",
     "license": "MIT",
     "homepage": "https://clangd.llvm.org/",


### PR DESCRIPTION
Bump the extension version to 0.6.0 for a stable release.

This promotes the InsertReplaceEdit support added in #954 and released as 0.5.0 pre-release to the stable update channel.

Stable version requested in #956 comments.